### PR TITLE
Fixes the hability to unlock just after it's been locked

### DIFF
--- a/Balance/macOS/View Controllers/Main App/LockViewController.swift
+++ b/Balance/macOS/View Controllers/Main App/LockViewController.swift
@@ -155,8 +155,8 @@ class LockViewController: NSViewController, NSTextFieldDelegate {
         AppDelegate.sharedInstance.promptTouchId()
     }
 
-    @objc fileprivate func unlock(force: Bool = false) {
-        if force || passwordField.stringValue == appLock.password {
+    @objc fileprivate func unlock() {
+        if passwordField.stringValue == appLock.password {
             NotificationCenter.postOnMainThread(name: Notifications.UnlockUserInterface)
             hintField.alphaValue = 0.0
             forgottenPasswordButton.isHidden = true
@@ -184,7 +184,7 @@ class LockViewController: NSViewController, NSTextFieldDelegate {
                     self.authenticateUserPassword(reason: "unlock Balance") { success, error in
                         if success {
                             appLock.lockEnabled = false
-                            self.unlock(force: true)
+                            NotificationCenter.postOnMainThread(name: Notifications.UnlockUserInterface)
                             async(after: 0.8) {
                                 NotificationCenter.postOnMainThread(name: Notifications.ShowPopover)
                             }


### PR DESCRIPTION
The unlock method was called on a non appropiate way (didn't detect really why).
By removing and having two sets of logic I was able to isolate the problem so it doesn't repeat
Now we have to explicitly call the unlock instead of a common method