### PR TITLE
Fix the screen cut off on singles screen

### DIFF
--- a/Balance/macOS/Frameworks/CCNStatusItem/CCNStatusItemWindowController.m
+++ b/Balance/macOS/Frameworks/CCNStatusItem/CCNStatusItemWindowController.m
@@ -103,8 +103,17 @@ typedef void (^CCNStatusItemWindowAnimationCompletion)(void);
 }
 
 - (void)updateWindowOrigin {
+    NSRect screenRect = [[NSScreen mainScreen] frame];
     CGRect statusItemRect = [[self.statusItemView.statusItem.button window] frame];
-    CGPoint windowOrigin = CGPointMake(NSMinX(statusItemRect) - NSWidth(self.window.frame) / 2 + NSWidth(statusItemRect) / 2,
+    
+    NSRect statusRectRelativeToScreen = [[self.statusItemView.statusItem.button window] convertRectToScreen:screenRect];
+    
+    CGFloat xOrigin = NSMinX(statusRectRelativeToScreen) - NSWidth(self.window.frame) / 2 + NSWidth(statusRectRelativeToScreen) / 2;
+    CGFloat screenOverflow = (xOrigin + NSWidth(self.window.frame)) - NSWidth(screenRect);
+    if (screenOverflow > 0) {
+        xOrigin = xOrigin - screenOverflow;
+    }
+    CGPoint windowOrigin = CGPointMake(xOrigin,
                                        NSMinY(statusItemRect) - NSHeight(self.window.frame) - self.windowConfiguration.windowToStatusItemMargin);
     [self.window setFrameOrigin:windowOrigin];
 }


### PR DESCRIPTION
Fix attempt on cutting.
problem is the way the lib works The arrow needs to be repositioned individually.
I can do this as part of another PR.
<img width="202" alt="screen shot 2017-10-20 at 16 38 00" src="https://user-images.githubusercontent.com/1092080/31826418-47074a54-b5b5-11e7-8e1d-3a6fb916b906.png">
