### PR TITLE
Disable code signing

### DIFF
--- a/Balance.xcodeproj/project.pbxproj
+++ b/Balance.xcodeproj/project.pbxproj
@@ -2119,7 +2119,7 @@
 						CreatedOnToolsVersion = 6.4;
 						DevelopmentTeam = Q4G66XSS36;
 						LastSwiftMigration = 0900;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.InAppPurchase = {
 								enabled = 1;
@@ -2913,8 +2913,8 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Balance/macOS/Supporting Files/Balance.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
@@ -2946,8 +2946,8 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Balance/macOS/Supporting Files/Balance.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3076,8 +3076,8 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Balance/macOS/Supporting Files/Balance.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If for some reason the sqlcipher needs to be updated (you should never need to d
 - If you **found a bug**, [open an issue](https://github.com/balancemymoney/balance-open/issues/new).
 - If you **have a feature request**, [open an issue](https://github.com/balancemymoney/balance-open/issues/new).
 - If you **want to contribute**, submit a pull request.
-
+- Extra: We removed Code signing. Since we use keychain you will be prompted on this screen 5 times. You should press "Always allow". We haven't found a better way for this yet. <img width="434" alt="screen shot 2017-10-25 at 17 15 19" src="https://user-images.githubusercontent.com/1092080/32006966-842eac82-b9a8-11e7-994e-57d0cf5d0d9c.png">
 [swift-image]:https://img.shields.io/badge/swift-3.0-orange.svg
 [swift-url]: https://swift.org/
 [license-image]: https://img.shields.io/aur/license/yaourt.svg


### PR DESCRIPTION
Disable code signing so anyone can build the app without being in the team.

**Does this pull request close an issue? If so, which one?**
https://github.com/balancemymoney/balance-open/issues/173

**What does this pull request do? What does it change?**
Removes code automatic code sign, set it to manual and no code sign

