### PR TITLE
ETH balance in wallets not right

### DIFF
--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerAccount.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerAccount.swift
@@ -117,7 +117,7 @@ struct EthplorerAccountObject {
     
     var ethplorerAccounts: [EthplorerAccount] {
         var arrayOlder = [EthplorerAccount]()
-        let ethAccount = EthplorerAccount(type: .wallet, currency: self.currency, address: self.address, available: self.ETH.balance, altRate: 0, altCurrency: Currency.rawValue("BTC"), decimals: 8)
+        let ethAccount = EthplorerAccount(type: .wallet, currency: self.currency, address: self.address, available: self.ETH.balance, altRate: 1, altCurrency: Currency.eth, decimals: 8)
         arrayOlder.append(ethAccount)
         for ethplorerObject in self.tokens {
             var altRate: Double = 0

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
@@ -219,9 +219,9 @@ class EthplorerApi: ExchangeApi {
     }
     
     var altBalance: Int {
-        let altValance = altRate * available
-        let altBalance = altValance.integerFixedFiatDecimals()
-        return altBalance
+        let altBalance = altRate * available
+        let balance = altBalance.integerValueWith(decimals: altCurrency.decimals)
+        return balance
     }
     
     @discardableResult func updateLocalAccount(institution: Institution) -> Account? {


### PR DESCRIPTION
Don't rely on the rate that comes with ethplore (no rate) and use the default ETH balance to get the $ conversion with our custom conversion

**Does this pull request close an issue? If so, which one?**
https://github.com/balancemymoney/balance-open/issues/203

**What does this pull request do? What does it change?**
Changes the conversion from ETH to $ to ETH to ETH (and leave the conversion to the internal conversion service)

