### PR TITLE
Crash when tapping Account name in Touch Bar #206

### DIFF
--- a/Balance/macOS/View Controllers/Tabs/View Controllers/Touch Bar/AccountsTabTouchBar.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/Touch Bar/AccountsTabTouchBar.swift
@@ -18,6 +18,7 @@ fileprivate extension NSTouchBarItem.Identifier {
 @available(OSX 10.12.2, *)
 extension AccountsTabViewController : NSTouchBarDelegate {
     override func makeTouchBar() -> NSTouchBar? {
+        return nil
         let touchBar = NSTouchBar()
         touchBar.delegate = self
         touchBar.defaultItemIdentifiers = [.searchTransactions, .accountsScrollView]

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/Touch Bar/TransactionsTabTouchBar.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/Touch Bar/TransactionsTabTouchBar.swift
@@ -36,6 +36,7 @@ fileprivate extension NSTouchBarItem.Identifier {
 @available(OSX 10.12.2, *)
 extension TransactionsTabViewController : NSTouchBarDelegate, NSScrubberDelegate, NSScrubberDataSource, NSScrubberFlowLayoutDelegate {
     override func makeTouchBar() -> NSTouchBar? {
+        return nil
         let touchBar = NSTouchBar()
         touchBar.delegate = self
         touchBar.customizationIdentifier = .main


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Crash when tapping Account name in Touch Bar #206

**What does this pull request do? What does it change?**
Disabled touch bar code until we bring back searching in the very near future

