### PR TITLE
Improve sync interval #217

### DIFF
--- a/Balance/Shared/Data Model/Syncing/SyncDefaults.swift
+++ b/Balance/Shared/Data Model/Syncing/SyncDefaults.swift
@@ -16,8 +16,19 @@ class SyncDefaults {
     
     fileprivate let userDefaults = UserDefaults.standard
     
-    // Regularly sync every 20 minutes
-    var syncInterval = 20.0 * 60.0
+    // Sync every minute while visible
+    fileprivate let activeSyncInterval = 60.0
+    // Regularly sync every 30 minutes
+    fileprivate let inactiveSyncInterval = 60.0 * 30.0
+    
+    var syncInterval: Double {
+        #if os(OSX)
+            let isActive = AppDelegate.sharedInstance.statusItem.isStatusItemWindowVisible
+        #else
+            let isActive = (UIApplication.shared.applicationState == .active)
+        #endif
+        return isActive ? activeSyncInterval : inactiveSyncInterval
+    }
     
     var lastSyncTime: Date {
         get {


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Improve sync interval #217

**What does this pull request do? What does it change?**
Sync interval is now at 30 min in the background, 1 min in the foreground, and the app syncs every time it becomes active. So no more opening the app and seeing outdated values and wondering where your latest transactions and balance changes are. Now the removed manual sync button is officially unnecessary.

