### PR TITLE
[UI] set the expanded height by calculating

### DIFF
--- a/Balance/iOS/Views/Collection View/Cells/InstitutionCollectionViewCell.swift
+++ b/Balance/iOS/Views/Collection View/Cells/InstitutionCollectionViewCell.swift
@@ -31,9 +31,7 @@ internal final class InstitutionCollectionViewCell: UICollectionViewCell, Reusab
     }
     
     // Internal
-    internal var expandedContentHeight: CGFloat {
-        return self.tableView.contentSize.height
-    }
+    internal private(set) var expandedContentHeight: CGFloat = 0.0
     
     internal var closedContentHeight: CGFloat {
         return 120.0
@@ -86,6 +84,12 @@ internal final class InstitutionCollectionViewCell: UICollectionViewCell, Reusab
     private func reloadData() {
         self.container.backgroundColor = self.viewModel?.institution.source.color
         self.tableView.reloadData()
+        
+        guard let unwrappedViewModel = self.viewModel else {
+            return
+        }
+        
+        self.expandedContentHeight = CGFloat(unwrappedViewModel.numberOfAccounts) * AccountTableViewCell.height + InstitutionTableHeaderView.height
     }
 }
 


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
Bug

**Does this pull request close an issue? If so, which one?**
https://github.com/balancemymoney/balance-open/issues/245

**What does this pull request do? What does it change?**
Manually calculate the height rather than using the table views content size
