### PR TITLE
Fixed crash when parsing Kraken withdrawal transactions

### DIFF
--- a/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
+++ b/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
@@ -98,7 +98,7 @@ internal extension KrakenAPIClient
                 {
                     do
                     {
-                        let currencyCode = self.transformKrakenCurrencyToCurrencyCode(currency: currency)
+                        let currencyCode = KrakenAPIClient.transformKrakenCurrencyToCurrencyCode(currency: currency)
                         let account = try Account(currency: currencyCode, balance: balance)
                         accounts.append(account)
                     }
@@ -392,7 +392,7 @@ internal extension Dictionary where Key: StringProtocol, Value: StringProtocol
 // run into issues. Thankfully they use XZEC for ZCASH tokens.
 
 extension KrakenAPIClient {
-    func transformKrakenCurrencyToCurrencyCode(currency: String) -> String {
+    static func transformKrakenCurrencyToCurrencyCode(currency: String) -> String {
         var currencyCode = currency
         if currency.count == 4 && (currency.hasPrefix("Z") || currency.hasPrefix("X")) {
             currencyCode = currency.substring(from: 1)

--- a/Balance/Shared/Data Model/Kraken/KrakenTransaction.swift
+++ b/Balance/Shared/Data Model/Kraken/KrakenTransaction.swift
@@ -28,16 +28,18 @@ internal extension KrakenAPIClient {
             self.refid = try checkType(dictionary["refid"], name: "refid")
             let timestamp: Double = try checkType(dictionary["time"], name: "timestamp")
             self.time = Date(timeIntervalSince1970: timestamp)
-            self.type = TxType.init(rawValue: dictionary["type"] as! String)!
-            self.aclass = Aclass.init(rawValue: dictionary["aclass"] as! String)!
+            let typeString: String = try checkType(dictionary["type"], name: "typeString")
+            self.type = try checkType(TxType(rawValue: typeString), name: "type")
+            let aclassString: String = try checkType(dictionary["aclass"], name: "aclassString")
+            self.aclass = try checkType(Aclass(rawValue: aclassString), name: "aclass")
             let krakenCurrencyCode: String = try checkType(dictionary["asset"], name: "krakenCurrencyCode")
-            self.asset = Currency.rawValue(KrakenAPIClient().transformKrakenCurrencyToCurrencyCode(currency: krakenCurrencyCode))
-            let fee: String = try checkType(dictionary["fee"], name: "fee")
-            self.fee = Double(fee)!
-            let balance: String = try checkType(dictionary["balance"], name: "balance")
-            self.balance = Double(balance)!
-            let amount: String = try checkType(dictionary["amount"], name: "amount")
-            self.amount = Double(amount)!
+            self.asset = Currency.rawValue(KrakenAPIClient.transformKrakenCurrencyToCurrencyCode(currency: krakenCurrencyCode))
+            let fee: String = try checkType(dictionary["fee"], name: "feeString")
+            self.fee = try checkType(Double(fee), name: "fee")
+            let balance: String = try checkType(dictionary["balance"], name: "balanceString")
+            self.balance = try checkType(Double(balance), name: "balance")
+            let amount: String = try checkType(dictionary["amount"], name: "amountString")
+            self.amount = try checkType(Double(amount), name: "amount")
         }
     }
     
@@ -47,7 +49,7 @@ internal extension KrakenAPIClient {
     
     enum TxType: String {
         case deposit
-        case withdrawl
+        case withdrawal
         case trade
         case margin
     }


### PR DESCRIPTION
Also fixed a bunch of force unwrapping that could cause other Kraken transaction parsing crashes

**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
no

**What does this pull request do? What does it change?**
Fixes a crash when parsing kraken withdrawals due to a typo, and preemptively fixes other potential parsing crashes due to forced unwrapping

