### PR TITLE
Exchange rates file created in Documents folder #311

### DIFF
--- a/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
+++ b/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
@@ -29,7 +29,7 @@ class CurrentExchangeRates {
     fileprivate let cachedRates = SimpleCache<String, Rate>()
     fileprivate let persistedFileName = "currentExchangeRates.data"
     fileprivate var persistedFileUrl: URL {
-        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(persistedFileName)
+        return appSupportPathUrl.appendingPathComponent(persistedFileName)
     }
     
     func exchangeRates(forSource source: ExchangeRateSource) -> [ExchangeRate]? {

--- a/Balance/Shared/Data Model/Singleton/Utils.swift
+++ b/Balance/Shared/Data Model/Singleton/Utils.swift
@@ -45,13 +45,7 @@ var appSupportPathUrl: URL = {
     
     let appSupportUrl = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
     let pathUrl = appSupportUrl.appendingPathComponent("Balance", isDirectory: true)
-    
-    do {
-        try fileManager.createDirectory(at: pathUrl, withIntermediateDirectories: true, attributes: nil)
-    } catch {
-        // Nothing to do here, it's not like we can log it! This should never happen.
-    }
-    
+    try? fileManager.createDirectory(at: pathUrl, withIntermediateDirectories: true, attributes: nil)
     return pathUrl
 }()
 


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
#311

**What does this pull request do? What does it change?**
We were incorrectly placing the exchange rate data file into the user's Documents folder instead of Application Support.

