### PR TITLE
314: bitfinex transactions wrong order

### DIFF
--- a/Balance/Shared/Data Model/Bitfinex/BitfinexTransaction.swift
+++ b/Balance/Shared/Data Model/Bitfinex/BitfinexTransaction.swift
@@ -65,8 +65,8 @@ internal extension BitfinexAPIClient
                   let address = data[16] as? String,
                   let status = data[9] as? String,
                   let amount = data[12] as? Double,
-                  let createdAtTimeInterval = data[6] as? TimeInterval,
-                  let movementTimeInterval = data[5] as? TimeInterval else
+                  let createdAtTimeInterval = data[6] as? Double,
+                  let movementTimeInterval = data[5] as? Double else
             {
                 throw BitfinexAPIClient.ModelError.invalidJSON(json: data)
             }
@@ -75,8 +75,9 @@ internal extension BitfinexAPIClient
             self.address = address
             self.status = status
             self.amount = amount
-            self.createdAt = Date(timeIntervalSince1970: createdAtTimeInterval)
-            self.movementTimestamp = Date(timeIntervalSince1970: movementTimeInterval)
+            // Dates in bitfinex are in miliseconds and Date only accepts timestamp in seconds
+            self.createdAt = Date(timeIntervalSince1970: createdAtTimeInterval.milisecondsToSeconds())
+            self.movementTimestamp = Date(timeIntervalSince1970: movementTimeInterval.milisecondsToSeconds())
         }
     }
 }

--- a/Balance/Shared/Data Model/Extensions/Double.swift
+++ b/Balance/Shared/Data Model/Extensions/Double.swift
@@ -34,5 +34,9 @@ extension Double {
         let decimal = self / pow(10.0, Double(decimals))
         return decimal
     }
+    
+    func milisecondsToSeconds() -> Double {
+        return self/1000.0
+    }
 }
 


### PR DESCRIPTION
**Does this pull request close an issue? If so, which one?**
#314 

**What does this pull request do? What does it change?**
Parse properly bitfinex timestamp date on transactions so they are not in the future (dates where 1000 times more fare away since we where taking miliseconds as seconds)

