### PR TITLE
Task/improve currency conversions

### DIFF
--- a/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
+++ b/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
@@ -75,8 +75,14 @@ struct CoinbaseApi: ExchangeApi {
         // TODO: Create enum types for each error
         let task = certValidatedSession.dataTask(with: request) { maybeData, maybeResponse, maybeError in
             do {
+                // Check for network errors
+                guard maybeError == nil else {
+                    log.error("Failed with network error: \(String(describing: maybeError))")
+                    throw BalanceError.networkError
+                }
+                
                 // Make sure there's data
-                guard let data = maybeData, maybeError == nil else {
+                guard let data = maybeData else {
                     throw BalanceError.noData
                 }
                 
@@ -136,14 +142,15 @@ struct CoinbaseApi: ExchangeApi {
         // TODO: Create enum types for each error
         let task = certValidatedSession.dataTask(with: request) { maybeData, maybeResponse, maybeError in
             do {
-                // Make sure there's data
-                guard let data = maybeData else {
-                    throw BalanceError.noData
-                }
-                
+                // Check for network errors
                 guard maybeError == nil else {
                     log.error("Failed with network error: \(String(describing: maybeError))")
                     throw BalanceError.networkError
+                }
+                
+                // Make sure there's data
+                guard let data = maybeData else {
+                    throw BalanceError.noData
                 }
                 
                 // Try to parse the JSON
@@ -186,8 +193,14 @@ struct CoinbaseApi: ExchangeApi {
         // TODO: Create enum types for each error
         let task = certValidatedSession.dataTask(with: request) { maybeData, maybeResponse, maybeError in
             do {
+                // Check for network errors
+                guard maybeError == nil else {
+                    log.error("Failed with network error: \(String(describing: maybeError))")
+                    throw BalanceError.networkError
+                }
+                
                 // Make sure there's data
-                guard let data = maybeData, maybeError == nil else {
+                guard let data = maybeData else {
                     throw BalanceError.noData
                 }
                 

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerAccount.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerAccount.swift
@@ -14,8 +14,8 @@ struct EthplorerAccount {
     
     let address: String
     let available: Double
-    let altRate: Double
-    let altCurrency: Currency
+    let altRate: Double?
+    let altCurrency: Currency?
     let decimals: Int
 }
 
@@ -121,7 +121,7 @@ struct EthplorerAccountObject {
         arrayOlder.append(ethAccount)
         for ethplorerObject in self.tokens {
             var altRate: Double = 0
-            var altCurrency: Currency = .usd
+            var altCurrency: Currency?
             if let tokenPrice = ethplorerObject.tokenInfo.price {
                 altRate = tokenPrice.rate
                 altCurrency = tokenPrice.currency

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
@@ -217,22 +217,22 @@ class EthplorerApi: ExchangeApi {
         return balance
     }
     
-    var altBalance: Int {
-        let altBalance = altRate * available
-        let balance = altBalance.integerValueWith(decimals: altCurrency.decimals)
-        return balance
+    var altBalance: Int? {
+        if let altRate = altRate, let altCurrency = altCurrency {
+            let altBalance = altRate * available
+            let balance = altBalance.integerValueWith(decimals: altCurrency.decimals)
+            return balance
+        }
+        return nil
     }
     
     @discardableResult func updateLocalAccount(institution: Institution) -> Account? {
         // Calculate the integer value of the balance based on the decimals
-        let currentBalance = balance
-        let altCurrentBalance = altBalance
-        
-        if let newAccount = AccountRepository.si.account(institutionId: institution.institutionId, source: institution.source, sourceAccountId: currency.code, sourceInstitutionId: "", accountTypeId: .wallet, accountSubTypeId: nil, name: currency.name, currency: currency.code, currentBalance: currentBalance, availableBalance: nil, number: nil, altCurrency: altCurrency.code, altCurrentBalance: altCurrentBalance, altAvailableBalance: nil) {
+        if let newAccount = AccountRepository.si.account(institutionId: institution.institutionId, source: institution.source, sourceAccountId: currency.code, sourceInstitutionId: "", accountTypeId: .wallet, accountSubTypeId: nil, name: currency.name, currency: currency.code, currentBalance: balance, availableBalance: nil, number: nil, altCurrency: altCurrency?.code, altCurrentBalance: altBalance, altAvailableBalance: nil) {
             
             // Hide unpoplular currencies that have a 0 balance
             if currency != Currency.btc && currency != Currency.eth {
-                newAccount.isHidden = (currentBalance == 0)
+                newAccount.isHidden = (balance == 0)
             }
             
             return newAccount

--- a/Balance/Shared/Data Model/Exchange Rates/ExchangeRateSource.swift
+++ b/Balance/Shared/Data Model/Exchange Rates/ExchangeRateSource.swift
@@ -13,12 +13,16 @@ public enum ExchangeRateSource: Int {
     case poloniex     = 2
     case bitfinex     = 3
     case kraken       = 4
+    case kucoin       = 5
+    case hitbtc       = 6
+    case binance      = 7
     
     // Fiat
     case fixer        = 10001
     
     public var url: URL {
         switch self {
+        // Crypto
         case .coinbaseGdax:
             return URL(string: "https://api.coinbase.com/v2/prices/usd/spot")!
         case .poloniex:
@@ -29,7 +33,14 @@ public enum ExchangeRateSource: Int {
         case .kraken:
             // TODO: Call https://api.kraken.com/0/public/AssetPairs API to get the current asset pairs instead of updating manually
             return URL(string: "https://api.kraken.com/0/public/Ticker?pair=BCHUSD,DASHUSD,XETCZUSD,XETHZUSD,XLTCZUSD,XXBTZUSD,XXMRZUSD,XXRPZUSD,XZECZUSD,EOSXBT,GNOXBT,XICNXXBT,XMLNXXBT,XREPXXBT,XXDGXXBT,XXLMXXBT,XXMRXXBT")!
+        case .kucoin:
+            return URL(string: "https://api.kucoin.com/v1/open/tick")!
+        case .hitbtc:
+            return URL(string: "https://api.hitbtc.com/api/2/public/ticker")!
+        case .binance:
+            return URL(string: "https://api.binance.com/api/v1/ticker/allPrices")!
             
+        // Fiat
         case .fixer:
             return URL(string: "http://api.fixer.io/latest?base=USD")!
         }
@@ -60,14 +71,14 @@ public enum ExchangeRateSource: Int {
     // These are the currencies that values are stored in for this exchange (i.e. Poloniex only has BTC and ETC, but not fiat currencies)
     public var mainCurrencies: [Currency] {
         switch self {
-        case .poloniex: return [.btc, .eth]
-        case .kraken: return [.usd, .btc]
-        default: return [.usd]
+            //        case .poloniex: return [.btc, .eth]
+        //        case .kraken: return [.usd, .btc]
+        default: return [.btc, .eth, .usd]
         }
     }
     
     public static var allCrypto: [ExchangeRateSource] {
-        return [.coinbaseGdax, .poloniex, .bitfinex, .kraken]
+        return [.coinbaseGdax, .poloniex, .bitfinex, .kraken, .kucoin, .hitbtc, .binance]
     }
     
     public static var allFiat: [ExchangeRateSource] {
@@ -83,10 +94,11 @@ extension Source {
     public var exchangeRateSource: ExchangeRateSource {
         switch self {
         //case .plaid:    return "Plaid"
-        case .coinbase, .gdax, .ethplorer:  return .coinbaseGdax
-        case .poloniex:                     return .poloniex
-        case .bitfinex:                     return .bitfinex
-        case .kraken:                       return .kraken
+        case .coinbase, .gdax:  return .coinbaseGdax
+        case .poloniex:         return .poloniex
+        case .bitfinex:         return .bitfinex
+        case .kraken:           return .kraken
+        case .ethplorer:        return .hitbtc
         }
     }
 }

--- a/Balance/Shared/Data Model/Singleton/CertValidator.m
+++ b/Balance/Shared/Data Model/Singleton/CertValidator.m
@@ -82,6 +82,13 @@ const NSString *geoTrustGlobalCA           = @"7HIpactkIAq2Y49orFOOQKurWxmmSFZhB
                           kTSKPublicKeyHashes : @[letsEncryptAuthorityX3, dstRootCAX3],
                           kTSKReportUris : @[balanceReportUri]
                           },
+                  @"countly.balancemy.money" : @{
+                          kTSKEnforcePinning : @YES,
+                          kTSKPublicKeyAlgorithms : @[kTSKAlgorithmRsa2048],
+                          kTSKPublicKeyHashes : @[letsEncryptAuthorityX3, dstRootCAX3],
+                          kTSKReportUris : @[balanceReportUri]
+                          },
+                  
                   @"api.coinbase.com" : @{
                           kTSKEnforcePinning : @YES,
                           kTSKPublicKeyAlgorithms : @[kTSKAlgorithmRsa2048],

--- a/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
+++ b/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
@@ -36,7 +36,7 @@ class CurrentExchangeRates {
         return cache.get(valueForKey: source)
     }
     
-    func convertTicker(amount: Double, from:Currency, to: Currency) -> Double? {
+    func convertTicker(amount: Double, from: Currency, to: Currency) -> Double? {
         if let exchangeRate = cachedRates.get(valueForKey: "\(from.code)-\(to.code)") {
             return amount * exchangeRate.rate
         } else {
@@ -101,7 +101,9 @@ class CurrentExchangeRates {
                 }
             }
         }
-        return nil
+        
+        // If we fail to convert, then use the non-source-specific convertTicker function
+        return convertTicker(amount: amount, from: from, to: to)
     }
     
     public func directConvert(amount: Double, from: Currency, to: Currency, source: ExchangeRateSource) -> Double? {

--- a/Balance/Shared/Data Model/Sqlite Models/Account.swift
+++ b/Balance/Shared/Data Model/Sqlite Models/Account.swift
@@ -135,7 +135,7 @@ extension Account {
     
     var masterAltCurrentBalance: Int? {
         let masterCurrency = defaults.masterCurrency!
-        
+
         // First check if an alt current balance was returned from the server. If so, either use that directly or convert it
         if let altCurrentBalance = altCurrentBalance, let altCurrency = altCurrency {
             if altCurrency == masterCurrency.code {


### PR DESCRIPTION
Improves exchange rate conversion fallback so that random altcoins and tokens will show prices now. Also fixes the bug where Metamask tokens with no price showed $0.00 instead of blank.

I can finally see my QSP holdings added to my total price! yay!