### PR TITLE
Different prices on ios and mac

### DIFF
--- a/Balance/Shared/Data Model/Exchange Rates/ExchangeRateSource.swift
+++ b/Balance/Shared/Data Model/Exchange Rates/ExchangeRateSource.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public enum ExchangeRateSource: Int {
     // Crypto
+    case average      = 0
     case coinbaseGdax = 1
     case poloniex     = 2
     case bitfinex     = 3
@@ -21,7 +22,7 @@ public enum ExchangeRateSource: Int {
     case fixer        = 10001
     
     // These are the currencies that values are stored in for this exchange (i.e. Poloniex only has BTC and ETC, but not fiat currencies)
-    public var mainCurrencies: [Currency] {
+    public static var mainCurrencies: [Currency] {
         switch self {
             //        case .poloniex: return [.btc, .eth]
         //        case .kraken: return [.usd, .btc]
@@ -30,7 +31,7 @@ public enum ExchangeRateSource: Int {
     }
     
     public static var allCrypto: [ExchangeRateSource] {
-        return [.coinbaseGdax, .poloniex, .bitfinex, .kraken, .kucoin, .hitbtc, .binance]
+        return [.average, .coinbaseGdax, .poloniex, .bitfinex, .kraken, .kucoin, .hitbtc, .binance]
     }
     
     public static var allFiat: [ExchangeRateSource] {

--- a/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
+++ b/Balance/Shared/Data Model/Singleton/CurrentExchangeRates.swift
@@ -36,11 +36,15 @@ class CurrentExchangeRates {
         return cache.get(valueForKey: source)
     }
     
+    func allExchangeRates() -> [ExchangeRate]? {
+        return cache.getAll().flatMap({$0.value}) as [ExchangeRate]?
+    }
+    
     func convertTicker(amount: Double, from: Currency, to: Currency) -> Double? {
         if let exchangeRate = cachedRates.get(valueForKey: "\(from.code)-\(to.code)") {
             return amount * exchangeRate.rate
         } else {
-            for masterCurrency in ExchangeRateSource.all.flatMap({ $0.mainCurrencies }) {
+            for masterCurrency in ExchangeRateSource.mainCurrencies {
                 if let fromRate = cachedRates.get(valueForKey: "\(from.code)-\(masterCurrency.code)"), let toRate = cachedRates.get(valueForKey: "\(masterCurrency.code)-\(to.code)") {
                     return amount * fromRate.rate * toRate.rate
                 }
@@ -80,7 +84,7 @@ class CurrentExchangeRates {
                 return rate!
             } else {
                 //change currency and loop through all sources to get a connecting currency to use as middle point
-                for currency in source.mainCurrencies {
+                for currency in ExchangeRateSource.mainCurrencies {
                     var fromRate: Double? = getRate(from: from, to: currency, source: source)
                     var toRate: Double? = getRate(from: currency, to: to, source: source)
                     for source in ExchangeRateSource.all {
@@ -148,15 +152,19 @@ class CurrentExchangeRates {
                     self.cachedRates.set(value: opositeRate, forKey: opositeRate.key)
                 }
             }
-            //add hash for master currencies
-            let allMaster = ExchangeRateSource.all.flatMap({ $0.mainCurrencies })
-            for masterCurrency in allMaster {
-                for otherCurrency in allMaster {
+            
+            // filter all exchanges from cache to remain only the ones between main currencies
+            let allMainRates = self.cache.getAll().flatMap({$0.value.filter({ExchangeRateSource.mainCurrencies.contains($0.from) && ExchangeRateSource.mainCurrencies.contains($0.to) })})
+            
+            //add hash for master currencies -> for each currency pair we average the available options
+            for masterCurrency in ExchangeRateSource.mainCurrencies {
+                for otherCurrency in ExchangeRateSource.mainCurrencies {
                     if otherCurrency.code == masterCurrency.code { continue }
-                    if let exchangeRate = self.convert(amount: 1.0, from: masterCurrency, to: otherCurrency, source: .poloniex) {
-                        let rate = Rate(from: masterCurrency, to: masterCurrency, rate: exchangeRate)
-                        self.cachedRates.set(value: rate, forKey: "\(masterCurrency.code)-\(otherCurrency.code)")
-                    }
+                    let groupedExchangeRates = allMainRates.filter({$0.from == masterCurrency && $0.to == otherCurrency})
+                    let groupedRates = groupedExchangeRates.map({$0.rate})
+                    let averageRate = groupedRates.reduce(0, +)/Double(groupedRates.count)
+                    let rate = Rate(from: masterCurrency, to: otherCurrency, rate: averageRate)
+                    self.cachedRates.set(value: rate, forKey: "\(masterCurrency.code)-\(otherCurrency.code)")
                 }
             }
         }
@@ -197,6 +205,8 @@ class CurrentExchangeRates {
                 self.cache.set(value: exchangeRates, forKey: source)
             }
         }
+        
+        //set cacheRates
         
         return true
     }

--- a/Balance/Shared/View Models/PriceTickerTabViewModel.swift
+++ b/Balance/Shared/View Models/PriceTickerTabViewModel.swift
@@ -14,12 +14,11 @@ class PriceTickerTabViewModel: TabViewModel {
     
     func reloadData() {
         let topCurrencyCodes = ["BTC", "ETH", "LTC", "BCH", "XRP", "DASH", "MIOTA", "ETC", "XMR", "LSK", "STEEM", "GNT", "ZRX"]
-        let topCurrencyCodesSet = Set<String>(topCurrencyCodes)
         
         var otherCurrenciesSet = Set<Currency>()
-        if let rates = currentExchangeRates.exchangeRates(forSource: .poloniex) {
+        if let rates = currentExchangeRates.allExchangeRates() {
             for rate in rates {
-                if !topCurrencyCodesSet.contains(rate.from.code) {
+                if !topCurrencyCodes.contains(rate.from.code) {
                     otherCurrenciesSet.insert(rate.from)
                 }
             }

--- a/Balance/iOS/Views/Collection View/Cells/CurrencyCollectionViewCell.swift
+++ b/Balance/iOS/Views/Collection View/Cells/CurrencyCollectionViewCell.swift
@@ -88,8 +88,8 @@ internal final class CurrencyCollectionViewCell: UICollectionViewCell, Reusable 
         guard let unwrappedCurrency = self.currency else {
             return
         }
-        
-        let convertedAmount = currentExchangeRates.convert(amount: 1.0, from: unwrappedCurrency, to: defaults.masterCurrency, source: .poloniex)?.integerValueWith(decimals: defaults.masterCurrency.decimals) ?? 0
+
+        let convertedAmount = currentExchangeRates.convertTicker(amount: 1.0, from: unwrappedCurrency, to: defaults.masterCurrency)?.integerValueWith(decimals: defaults.masterCurrency.decimals) ?? 0
         let convertedAmountString = amountToString(amount: convertedAmount, currency: defaults.masterCurrency, showNegative: true)
         
         self.currencyNameLabel.text = unwrappedCurrency.longName


### PR DESCRIPTION
Use same convert function for al the different price tickers ios and mac

**Does this pull request close an issue? If so, which one?**
#338 
**What does this pull request do? What does it change?**
averages all master currencies before adding them to the cache

