### PR TITLE
Add special case in price ticker for values under 1 cent. #360 

### DIFF
--- a/Balance/Shared/Data Model/Singleton/Utils.swift
+++ b/Balance/Shared/Data Model/Singleton/Utils.swift
@@ -129,13 +129,15 @@ fileprivate var amountFormatter: NumberFormatter = {
 }()
 
 // TODO: Add proper locale support for currency symbol location
-func amountToString(amount: Int, currency: Currency, showNegative: Bool = false, showCodeAfterValue: Bool = false)  -> String {
+func amountToString(amount: Int, currency: Currency, decimalsOverride: Int? = nil, showNegative: Bool = false, showCodeAfterValue: Bool = false)  -> String {
     assert(Thread.isMainThread, "Must be used from main thread")
     
-    let amount = Double(amount) / pow(10.0, Double(currency.decimals))
+    let decimals = decimalsOverride ?? currency.decimals
+    
+    let amount = Double(amount) / pow(10.0, Double(decimals))
     amountFormatter.currencySymbol = showCodeAfterValue ? "" : currency.symbol
-    amountFormatter.minimumFractionDigits = currency.decimals
-    amountFormatter.maximumFractionDigits = currency.decimals
+    amountFormatter.minimumFractionDigits = decimals
+    amountFormatter.maximumFractionDigits = decimals
     
     let amountString = amountFormatter.string(from: NSNumber(value: amount))!
     let minusRemoved = showNegative ? amountString : amountString.replacingOccurrences(of: "-", with: "")

--- a/Balance/Shared/View Models/PriceTickerTabViewModel.swift
+++ b/Balance/Shared/View Models/PriceTickerTabViewModel.swift
@@ -44,4 +44,22 @@ class PriceTickerTabViewModel: TabViewModel {
         }
         return nil
     }
+    
+    func ratesString(forRow row: Int, inSection section: Int) -> String {
+        var convertedAmountString = "Unknown"
+        if let currency = currency(forRow: row, inSection: section) {
+            if let convertedAmountDouble = currentExchangeRates.convertTicker(amount: 1.0, from: currency, to: defaults.masterCurrency) {
+                // Handle cases of less than one cent in fiat currencies
+                if defaults.masterCurrency.decimals == 2 && convertedAmountDouble < 0.01 {
+                    let decimals = 8
+                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: decimals)
+                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, decimalsOverride: decimals, showNegative: true)
+                } else {
+                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: defaults.masterCurrency.decimals)
+                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, showNegative: true)
+                }
+            }
+        }
+        return convertedAmountString
+    }
 }

--- a/Balance/iOS/View Controllers/Price Ticker/PriceTickerViewController.swift
+++ b/Balance/iOS/View Controllers/Price Ticker/PriceTickerViewController.swift
@@ -114,7 +114,10 @@ extension PriceTickerViewController: UICollectionViewDelegate {
             return
         }
         
-        currencyCell.currency = self.viewModel.currency(forRow: indexPath.row, inSection: indexPath.section)
+        if let currency = self.viewModel.currency(forRow: indexPath.row, inSection: indexPath.section) {
+            let rate = viewModel.ratesString(forRow: indexPath.row, inSection: indexPath.section)
+            currencyCell.update(currency: currency, rate: rate)
+        }
     }
 }
 

--- a/Balance/iOS/Views/Collection View/Cells/CurrencyCollectionViewCell.swift
+++ b/Balance/iOS/Views/Collection View/Cells/CurrencyCollectionViewCell.swift
@@ -13,14 +13,6 @@ internal final class CurrencyCollectionViewCell: UICollectionViewCell, Reusable 
     // Static
     static let height: CGFloat = 60.0
     
-    // Internal
-    internal var currency: Currency? {
-        didSet
-        {
-            self.reloadData()
-        }
-    }
-    
     // Private
     private let currencyNameLabel: UILabel = {
         let label = UILabel()
@@ -84,15 +76,8 @@ internal final class CurrencyCollectionViewCell: UICollectionViewCell, Reusable 
     
     // MARK: Data
     
-    private func reloadData() {
-        guard let unwrappedCurrency = self.currency else {
-            return
-        }
-
-        let convertedAmount = currentExchangeRates.convertTicker(amount: 1.0, from: unwrappedCurrency, to: defaults.masterCurrency)?.integerValueWith(decimals: defaults.masterCurrency.decimals) ?? 0
-        let convertedAmountString = amountToString(amount: convertedAmount, currency: defaults.masterCurrency, showNegative: true)
-        
-        self.currencyNameLabel.text = unwrappedCurrency.longName
-        self.amountLabel.text = convertedAmountString
+    func update(currency: Currency, rate: String) {
+        self.currencyNameLabel.text = currency.longName
+        self.amountLabel.text = rate
     }
 }

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
@@ -148,19 +148,8 @@ class PriceTickerTabViewController: NSViewController, SectionedTableViewDelegate
         cell.identifier = NSUserInterfaceItemIdentifier(rawValue: "Exchange Rate Cell")
         
         if let currency = viewModel.currency(forRow: row, inSection: section) {
-            var convertedAmountString = "Unknown"
-            if let convertedAmountDouble = currentExchangeRates.convertTicker(amount: 1.0, from: currency, to: defaults.masterCurrency) {
-                // Handle cases of less than one cent in fiat currencies
-                if defaults.masterCurrency.decimals == 2 && convertedAmountDouble < 0.01 {
-                    let decimals = 8
-                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: decimals)
-                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, decimalsOverride: decimals, showNegative: true)
-                } else {
-                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: defaults.masterCurrency.decimals)
-                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, showNegative: true)
-                }
-            }
-            cell.updateModel(currency: currency, rate: convertedAmountString)
+            let rate = viewModel.ratesString(forRow: row, inSection: section)
+            cell.updateModel(currency: currency, rate: rate)
         }
         return cell
     }

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
@@ -148,8 +148,18 @@ class PriceTickerTabViewController: NSViewController, SectionedTableViewDelegate
         cell.identifier = NSUserInterfaceItemIdentifier(rawValue: "Exchange Rate Cell")
         
         if let currency = viewModel.currency(forRow: row, inSection: section) {
-            let convertedAmount = currentExchangeRates.convertTicker(amount: 1.0, from: currency, to: defaults.masterCurrency)?.integerValueWith(decimals: defaults.masterCurrency.decimals) ?? 0
-            let convertedAmountString = amountToString(amount: convertedAmount, currency: defaults.masterCurrency, showNegative: true)
+            var convertedAmountString = "Unknown"
+            if let convertedAmountDouble = currentExchangeRates.convertTicker(amount: 1.0, from: currency, to: defaults.masterCurrency) {
+                // Handle cases of less than one cent in fiat currencies
+                if defaults.masterCurrency.decimals == 2 && convertedAmountDouble < 0.01 {
+                    let decimals = 8
+                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: decimals)
+                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, decimalsOverride: decimals, showNegative: true)
+                } else {
+                    let convertedAmountInt = convertedAmountDouble.integerValueWith(decimals: defaults.masterCurrency.decimals)
+                    convertedAmountString = amountToString(amount: convertedAmountInt, currency: defaults.masterCurrency, showNegative: true)
+                }
+            }
             cell.updateModel(currency: currency, rate: convertedAmountString)
         }
         return cell


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
#360 

**What does this pull request do? What does it change?**
Any currency in the ticker less than 1 cent now has 8 decimals so you can see it's price.

