### PR TITLE
Bug/sign up correct field names

### DIFF
--- a/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseInstitution.swift
@@ -22,8 +22,8 @@ class CoinbaseInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let keyField = Field(name: "Key", type: "key", value: nil)
-        let secretField = Field(name: "Secret", type: "secret", value: nil)
+        let keyField = Field(name: "Key", type: .key, value: nil)
+        let secretField = Field(name: "Secret", type: .secret, value: nil)
         self.fields = [keyField, secretField]
     }
 }

--- a/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseInstitution.swift
@@ -22,8 +22,8 @@ class CoinbaseInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let keyField = Field(name: "Key", label: "Key", type: "key", value: nil)
-        let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: nil)
+        let keyField = Field(name: "Key", type: "key", value: nil)
+        let secretField = Field(name: "Secret", type: "secret", value: nil)
         self.fields = [keyField, secretField]
     }
 }

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
@@ -52,9 +52,9 @@ class EthplorerApi: ExchangeApi {
         var nameField : String?
         var addressField : String?
         for field in loginStrings {
-            if field.type == "name" {
+            if field.type == .name {
                 nameField = field.value
-            } else if field.type == "address" {
+            } else if field.type == .address {
                 addressField = field.value
             } else {
                 assert(false, "wrong fields are passed into the Ethplore auth, we require secret and key fields and values")

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerInstitution.swift
@@ -22,8 +22,8 @@ class EthplorerInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let addressField = Field(name: "Public Address", type: "address", value: nil)
-        let nameField = Field(name: "Name", type: "name", value: nil)
+        let addressField = Field(name: "Public Address", type: .address, value: nil)
+        let nameField = Field(name: "Name", type: .name, value: nil)
         self.fields = [nameField, addressField]
     }
 }

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerInstitution.swift
@@ -22,8 +22,8 @@ class EthplorerInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let addressField = Field(name: "Address", label: "Address", type: "address", value: nil)
-        let nameField = Field(name: "Address Name", label: "Address Name", type: "name", value: nil)
+        let addressField = Field(name: "Public Address", type: "address", value: nil)
+        let nameField = Field(name: "Name", type: "name", value: nil)
         self.fields = [nameField, addressField]
     }
 }

--- a/Balance/Shared/Data Model/APIs/GDAX/GDAXAPIClient.swift
+++ b/Balance/Shared/Data Model/APIs/GDAX/GDAXAPIClient.swift
@@ -46,9 +46,9 @@ internal final class GDAXAPIClient
         var fields: [Field]
         
         init() {
-            let keyField = Field(name: "API Key", type: "key", value: nil)
-            let secretField = Field(name: "API Secret", type: "secret", value: nil)
-            let passphraseField = Field(name: "Passphrase", type: "passphrase", value: nil)
+            let keyField = Field(name: "API Key", type: .key, value: nil)
+            let secretField = Field(name: "API Secret", type: .secret, value: nil)
+            let passphraseField = Field(name: "Passphrase", type: .passphrase, value: nil)
             self.fields = [keyField, secretField, passphraseField]
         }
     }
@@ -237,11 +237,11 @@ extension GDAXAPIClient: ExchangeApi {
         var keyField : String?
         var passphrasField: String?
         for field in loginStrings {
-            if field.type == "key" {
+            if field.type == .key {
                 keyField = field.value
-            } else if field.type == "secret" {
+            } else if field.type == .secret {
                 secretField = field.value
-            } else if field.type == "passphrase" {
+            } else if field.type == .passphrase {
                 passphrasField = field.value
             } else {
                 assert(false, "wrong fields are passed into the poloniex auth, we require secret and key fields and values")

--- a/Balance/Shared/Data Model/APIs/GDAX/GDAXAPIClient.swift
+++ b/Balance/Shared/Data Model/APIs/GDAX/GDAXAPIClient.swift
@@ -46,9 +46,9 @@ internal final class GDAXAPIClient
         var fields: [Field]
         
         init() {
-            let keyField = Field(name: "Key", label: "Key", type: "key", value: nil)
-            let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: nil)
-            let passphraseField = Field(name: "Passphrase", label: "Passphrase", type: "passphrase", value: nil)
+            let keyField = Field(name: "API Key", type: "key", value: nil)
+            let secretField = Field(name: "API Secret", type: "secret", value: nil)
+            let passphraseField = Field(name: "Passphrase", type: "passphrase", value: nil)
             self.fields = [keyField, secretField, passphraseField]
         }
     }

--- a/Balance/Shared/Data Model/APIs/Poloniex/PoloniexApi.swift
+++ b/Balance/Shared/Data Model/APIs/Poloniex/PoloniexApi.swift
@@ -81,9 +81,9 @@ class PoloniexApi: ExchangeApi {
         var secretField : String?
         var keyField : String?
         for field in loginStrings {
-            if field.type == "key" {
+            if field.type == .key {
                 keyField = field.value
-            } else if field.type == "secret" {
+            } else if field.type == .secret {
                 secretField = field.value
             } else {
                 assert(false, "wrong fields are passed into the poloniex auth, we require secret and key fields and values")

--- a/Balance/Shared/Data Model/APIs/Poloniex/PoloniexInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Poloniex/PoloniexInstitution.swift
@@ -22,8 +22,8 @@ class PoloniexInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let keyField = Field(name: "API Key", type: "key", value: nil)
-        let secretField = Field(name: "Secret", type: "secret", value: nil)
+        let keyField = Field(name: "API Key", type: .key, value: nil)
+        let secretField = Field(name: "Secret", type: .secret, value: nil)
         self.fields = [keyField, secretField]
     }
 }

--- a/Balance/Shared/Data Model/APIs/Poloniex/PoloniexInstitution.swift
+++ b/Balance/Shared/Data Model/APIs/Poloniex/PoloniexInstitution.swift
@@ -22,8 +22,8 @@ class PoloniexInstitution: ApiInstitution {
     var fields: [Field]
     
     init() {
-        let keyField = Field(name: "Key", label: "Key", type: "key", value: nil)
-        let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: nil)
+        let keyField = Field(name: "API Key", type: "key", value: nil)
+        let secretField = Field(name: "Secret", type: "secret", value: nil)
         self.fields = [keyField, secretField]
     }
 }

--- a/Balance/Shared/Data Model/ApiInstitution.swift
+++ b/Balance/Shared/Data Model/ApiInstitution.swift
@@ -32,9 +32,6 @@ struct Field {
 }
 
 enum FieldType: String {
-    case username   = "username"
-    case password   = "password"
-    case pin        = "pin"
     case key        = "key"
     case secret     = "secret"
     case passphrase = "passphrase"

--- a/Balance/Shared/Data Model/ApiInstitution.swift
+++ b/Balance/Shared/Data Model/ApiInstitution.swift
@@ -27,8 +27,19 @@ protocol ApiInstitution {
 
 struct Field {
     var name: String
-    var type: String
+    var type: FieldType
     var value: String?
+}
+
+enum FieldType: String {
+    case username   = "username"
+    case password   = "password"
+    case pin        = "pin"
+    case key        = "key"
+    case secret     = "secret"
+    case passphrase = "passphrase"
+    case name       = "name"
+    case address    = "address"
 }
 
 extension Source {

--- a/Balance/Shared/Data Model/ApiInstitution.swift
+++ b/Balance/Shared/Data Model/ApiInstitution.swift
@@ -27,7 +27,6 @@ protocol ApiInstitution {
 
 struct Field {
     var name: String
-    var label: String
     var type: String
     var value: String?
 }

--- a/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
+++ b/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
@@ -48,8 +48,8 @@ internal final class BitfinexAPIClient
         // MARK: Initialization
         
         init() {
-            let keyField = Field(name: "Key", label: "Key", type: "key", value: nil)
-            let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: nil)
+            let keyField = Field(name: "API key", type: "key", value: nil)
+            let secretField = Field(name: "API key secret", type: "secret", value: nil)
             self.fields = [keyField, secretField]
         }
     }

--- a/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
+++ b/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
@@ -48,8 +48,8 @@ internal final class BitfinexAPIClient
         // MARK: Initialization
         
         init() {
-            let keyField = Field(name: "API key", type: "key", value: nil)
-            let secretField = Field(name: "API key secret", type: "secret", value: nil)
+            let keyField = Field(name: "API key", type: .key, value: nil)
+            let secretField = Field(name: "API key secret", type: .secret, value: nil)
             self.fields = [keyField, secretField]
         }
     }
@@ -216,9 +216,9 @@ extension BitfinexAPIClient: ExchangeApi {
         
         for field in loginStrings {
             switch field.type {
-            case "key":
+            case .key:
                 keyField = field.value
-            case "secret":
+            case .secret:
                 secretField = field.value
             default:
                 assert(false, "wrong fields are passed into the Bitfinex auth, we require secret and key fields and values")

--- a/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
+++ b/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
@@ -214,9 +214,9 @@ extension KrakenAPIClient: ExchangeApi {
 
         for field in loginStrings {
             switch field.type {
-            case "key":
+            case .key:
                 keyField = field.value
-            case "secret":
+            case .secret:
                 secretField = field.value
             default:
                 assert(false, "wrong fields are passed into the Kraken auth, we require secret and key fields and values")
@@ -356,8 +356,8 @@ internal extension KrakenAPIClient
         // MARK: Initialization
         
         init() {
-            let keyField = Field(name: "API Key", type: "key", value: nil)
-            let secretField = Field(name: "Private Key", type: "secret", value: nil)
+            let keyField = Field(name: "API Key", type: .key, value: nil)
+            let secretField = Field(name: "Private Key", type: .secret, value: nil)
             self.fields = [keyField, secretField]
         }
     }

--- a/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
+++ b/Balance/Shared/Data Model/Kraken/KrakenAPIClient.swift
@@ -356,8 +356,8 @@ internal extension KrakenAPIClient
         // MARK: Initialization
         
         init() {
-            let keyField = Field(name: "Key", label: "Key", type: "key", value: nil)
-            let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: nil)
+            let keyField = Field(name: "API Key", type: "key", value: nil)
+            let secretField = Field(name: "Private Key", type: "secret", value: nil)
             self.fields = [keyField, secretField]
         }
     }

--- a/Balance/iOS/Utilities/QRLoginCredentialsParser.swift
+++ b/Balance/iOS/Utilities/QRLoginCredentialsParser.swift
@@ -54,8 +54,8 @@ internal final class QRLoginCredentialsParser {
         }
         
         // Build fields
-        let keyField = Field(name: "Key", type: "key", value: key)
-        let secretField = Field(name: "Secret", type: "secret", value: secret)
+        let keyField = Field(name: "Key", type: .key, value: key)
+        let secretField = Field(name: "Secret", type: .secret, value: secret)
         
         return [keyField, secretField]
     }
@@ -87,8 +87,8 @@ internal final class QRLoginCredentialsParser {
         }
         
         // Build fields
-        let keyField = Field(name: "Key", type: "key", value: unwrappedBitfinexKey)
-        let secretField = Field(name: "Secret", type: "secret", value: unwrappedBitfinexSecret)
+        let keyField = Field(name: "Key", type: .key, value: unwrappedBitfinexKey)
+        let secretField = Field(name: "Secret", type: .secret, value: unwrappedBitfinexSecret)
         
         return [keyField, secretField]
     }

--- a/Balance/iOS/Utilities/QRLoginCredentialsParser.swift
+++ b/Balance/iOS/Utilities/QRLoginCredentialsParser.swift
@@ -54,8 +54,8 @@ internal final class QRLoginCredentialsParser {
         }
         
         // Build fields
-        let keyField = Field(name: "Key", label: "Key", type: "key", value: key)
-        let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: secret)
+        let keyField = Field(name: "Key", type: "key", value: key)
+        let secretField = Field(name: "Secret", type: "secret", value: secret)
         
         return [keyField, secretField]
     }
@@ -87,8 +87,8 @@ internal final class QRLoginCredentialsParser {
         }
         
         // Build fields
-        let keyField = Field(name: "Key", label: "Key", type: "key", value: unwrappedBitfinexKey)
-        let secretField = Field(name: "Secret", label: "Secret", type: "secret", value: unwrappedBitfinexSecret)
+        let keyField = Field(name: "Key", type: "key", value: unwrappedBitfinexKey)
+        let secretField = Field(name: "Secret", type: "secret", value: unwrappedBitfinexSecret)
         
         return [keyField, secretField]
     }

--- a/Balance/iOS/View Models/NewAccountViewModel.swift
+++ b/Balance/iOS/View Models/NewAccountViewModel.swift
@@ -18,7 +18,7 @@ final class NewAccountViewModel {
     var isValid: Bool {
         for index in 0 ..< fields.count {
             let textField = self.textField(at: index)
-            guard let text = textField?.text, text.lengthOfBytes(using: .utf8) > 0 else {
+            guard let text = textField.text, text.lengthOfBytes(using: .utf8) > 0 else {
                 return false
             }
         }
@@ -143,14 +143,13 @@ final class NewAccountViewModel {
     
     // MARK: Table data
     
-    func textField(at index: Int) -> UITextField? {
+    func textField(at index: Int) -> UITextField {
         switch fields[index].type {
         case .key:        return apiKeyTextField
         case .passphrase: return passphraseKeyTextField
         case .secret:     return secretKeyKeyTextField
         case .name:       return nameTextField
         case .address:    return addressTextField
-        default: return nil
         }
     }
     

--- a/Balance/iOS/View Models/NewAccountViewModel.swift
+++ b/Balance/iOS/View Models/NewAccountViewModel.swift
@@ -9,20 +9,16 @@
 import UIKit
 
 
-internal final class NewAccountViewModel
-{
+final class NewAccountViewModel {
     // Internal
-    internal var numberOfTextFields: Int {
-        return self.fieldTypes.count
+    var numberOfTextFields: Int {
+        return self.fields.count
     }
     
-    internal var isValid: Bool {
-        for index in 0..<self.fieldTypes.count
-        {
+    var isValid: Bool {
+        for index in 0 ..< fields.count {
             let textField = self.textField(at: index)
-            guard let text = textField.text,
-                  text.lengthOfBytes(using: .utf8) > 0 else
-            {
+            guard let text = textField?.text, text.lengthOfBytes(using: .utf8) > 0 else {
                 return false
             }
         }
@@ -30,9 +26,8 @@ internal final class NewAccountViewModel
         return true
     }
     
-    internal var loginWithQRCodeSupported: Bool {
-        switch self.source
-        {
+    var loginWithQRCodeSupported: Bool {
+        switch self.source {
         case .bitfinex, .kraken:
             return true
         default:
@@ -42,7 +37,7 @@ internal final class NewAccountViewModel
     
     // Private
     private let source: Source
-    private let fieldTypes: [FieldType]
+    private let fields: [Field]
     
     private let gdaxAPIClient = GDAXAPIClient(server: .production)
     private let poloniexAPIClient = PoloniexApi()
@@ -104,40 +99,22 @@ internal final class NewAccountViewModel
     internal init(source: Source)
     {
         self.source = source
-        
-        switch source
-        {
-        case .gdax:
-            self.fieldTypes = [.key, .secretKey, .passphrase]
-        case .poloniex:
-            self.fieldTypes = [.key, .secretKey]
-        case .kraken:
-            self.fieldTypes = [.key, .secretKey]
-        case .bitfinex:
-            self.fieldTypes = [.key, .secretKey]
-        case .ethplorer:
-            self.fieldTypes = [.name, .address]
-        default:
-            self.fieldTypes = []
-        }
+        self.fields = source.apiInstitution.fields
     }
     
     // MARK: Authenticate
     
     internal func authenticate(_ completionHandler: @escaping (_ success: Bool, _ error: Error?) -> Void) {
-        if !self.isValid
-        {
+        guard isValid else {
             completionHandler(false, nil)
             return
         }
         
-        let loginFields = self.buildLoginFields()
-        self.authenticate(with: loginFields, completionHandler: completionHandler)
+        self.authenticate(with: fields, completionHandler: completionHandler)
     }
     
     internal func authenticate(with fields: [Field], completionHandler: @escaping (_ success: Bool, _ error: Error?) -> Void) {
-        switch self.source
-        {
+        switch self.source {
         case .gdax:
             self.gdaxAPIClient.authenticationChallenge(loginStrings: fields, closeBlock: { (success, error, _) in
                 completionHandler(success, error)
@@ -163,89 +140,22 @@ internal final class NewAccountViewModel
         }
     }
     
-    private func buildLoginFields() -> [Field]
-    {
-        var fields = [Field]()
-        for type in self.fieldTypes
-        {
-            let field: Field
-            switch type
-            {
-            case .key:
-                field = Field(name: "Key", label: "Key", type: "key", value: self.apiKeyTextField.text)
-            case .secretKey:
-                field = Field(name: "Secret", label: "Secret", type: "secret", value: self.secretKeyKeyTextField.text)
-            case .passphrase:
-                field = Field(name: "Passphrase", label: "Passphrase", type: "passphrase", value: self.passphraseKeyTextField.text)
-            case .name:
-                field = Field(name: "Name", label: "Name", type: "name", value: self.nameTextField.text)
-            case .address:
-                field = Field(name: "Address", label: "Address", type: "address", value: self.addressTextField.text)
-            }
-            
-            fields.append(field)
-        }
-        
-        return fields
-    }
     
     // MARK: Table data
     
-    internal func textField(at index: Int) -> UITextField
-    {
-        let type = self.fieldTypes[index]
-        
-        switch type
-        {
-        case .key:
-            return self.apiKeyTextField
-        case .passphrase:
-            return self.passphraseKeyTextField
-        case .secretKey:
-            return self.secretKeyKeyTextField
-        case .name:
-            return self.nameTextField
-        case .address:
-            return self.addressTextField
+    func textField(at index: Int) -> UITextField? {
+        switch fields[index].type {
+        case .key:        return apiKeyTextField
+        case .passphrase: return passphraseKeyTextField
+        case .secret:     return secretKeyKeyTextField
+        case .name:       return nameTextField
+        case .address:    return addressTextField
+        default: return nil
         }
     }
     
-    internal func title(at index: Int) -> String
-    {
-        let type = self.fieldTypes[index]
-        return type.title()
-    }
-}
-
-// MARK: FieldType
-
-internal extension NewAccountViewModel
-{
-    internal enum FieldType
-    {
-        case key
-        case secretKey
-        case passphrase
-        case name
-        case address
-        
-        // MARK: Description
-        
-        internal func title() -> String
-        {
-            switch self
-            {
-            case .key:
-                return "Key"
-            case .secretKey:
-                return "Secret"
-            case .passphrase:
-                return "Passphrase"
-            case .name:
-                return "Name"
-            case .address:
-                return "Address"
-            }
-        }
+    func title(at index: Int) -> String {
+        let field = fields[index]
+        return field.name
     }
 }

--- a/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
+++ b/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
@@ -427,23 +427,13 @@ class SignUpViewController: NSViewController {
     fileprivate func displayConnectFields() {
         var previousTextField: SignUpTextField?
         for field in apiInstitution.fields {
-            var type: SignUpTextFieldType = .username
-            if field.type == FieldType.username {
-                type = .username
-            } else if field.type == FieldType.password {
-                type = .password
-            } else if field.type == FieldType.pin {
-                type = .pin
-            } else if field.type == FieldType.passphrase {
-                type = .passphrase
-            } else if field.type == FieldType.key {
-                type = .key
-            } else if field.type == FieldType.secret {
-                type = .secret
-            }else if field.type == FieldType.name {
-                type = .name
-            } else if field.type == FieldType.address {
-                type = .address
+            let type: SignUpTextFieldType
+            switch field.type {
+            case .passphrase: type = .passphrase
+            case .key:        type = .key
+            case .secret:     type = .secret
+            case .name:       type = .name
+            case .address:    type = .address
             }
             
             let textField = SignUpTextField(type: type)

--- a/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
+++ b/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
@@ -8,17 +8,6 @@
 
 import Cocoa
 
-private enum FieldType: String {
-    case username   = "username"
-    case password   = "password"
-    case pin        = "pin"
-    case key        = "key"
-    case secret     = "secret"
-    case passphrase = "passphrase"
-    case name       = "name"
-    case address    = "address"
-}
-
 private enum Step: String {
     case connect    = "connect"
     case question   = "question"
@@ -42,13 +31,17 @@ func ==(lhs: Device, rhs: Device) -> Bool {
 }
 
 extension SignUpTextField {
-    var field: Field {
+    var field: Field? {
+        guard let fieldType = FieldType(rawValue: type.rawValue) else {
+            return nil
+        }
+        
         let value = textField.stringValue
         switch self.type {
         case .none:
-            return Field(name: type.rawValue, type: type.rawValue, value: nil)
+            return Field(name: type.rawValue, type: fieldType, value: nil)
         default:
-            return Field(name: type.rawValue, type: type.rawValue, value: value)
+            return Field(name: type.rawValue, type: fieldType, value: value)
         }
     }
 }
@@ -435,21 +428,21 @@ class SignUpViewController: NSViewController {
         var previousTextField: SignUpTextField?
         for field in apiInstitution.fields {
             var type: SignUpTextFieldType = .username
-            if field.type == FieldType.username.rawValue {
+            if field.type == FieldType.username {
                 type = .username
-            } else if field.type == FieldType.password.rawValue {
+            } else if field.type == FieldType.password {
                 type = .password
-            } else if field.type == FieldType.pin.rawValue {
+            } else if field.type == FieldType.pin {
                 type = .pin
-            } else if field.type == FieldType.passphrase.rawValue {
+            } else if field.type == FieldType.passphrase {
                 type = .passphrase
-            } else if field.type == FieldType.key.rawValue {
+            } else if field.type == FieldType.key {
                 type = .key
-            } else if field.type == FieldType.secret.rawValue {
+            } else if field.type == FieldType.secret {
                 type = .secret
-            }else if field.type == FieldType.name.rawValue {
+            }else if field.type == FieldType.name {
                 type = .name
-            } else if field.type == FieldType.address.rawValue {
+            } else if field.type == FieldType.address {
                 type = .address
             }
             
@@ -616,7 +609,9 @@ class SignUpViewController: NSViewController {
 
         var loginFields = [Field]()
         for textField in connectFields {
-            loginFields.append(textField.field)
+            if let field = textField.field {
+                loginFields.append(field)
+            }
         }
         // try login with loginFields
         loginService.authenticationChallenge(loginStrings: loginFields) { success, error, institution in

--- a/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
+++ b/Balance/macOS/View Controllers/Add Account Workflow/SignUpViewController.swift
@@ -46,9 +46,9 @@ extension SignUpTextField {
         let value = textField.stringValue
         switch self.type {
         case .none:
-            return Field(name: type.rawValue, label: type.rawValue, type: type.rawValue, value: nil)
+            return Field(name: type.rawValue, type: type.rawValue, value: nil)
         default:
-            return Field(name: type.rawValue, label: type.rawValue, type: type.rawValue, value: value)
+            return Field(name: type.rawValue, type: type.rawValue, value: value)
         }
     }
 }
@@ -430,38 +430,6 @@ class SignUpViewController: NSViewController {
         reportFailureField.removeFromSuperview()
     }
     
-    fileprivate func generatePlaceholder(field: Field) -> String {
-        let lowercaseLabel = field.label.lowercased()
-        if lowercaseLabel == "account number/userid" {
-            return "Account Number or User ID"
-        } else if lowercaseLabel == "account number" {
-            return "02610642"
-        } else if lowercaseLabel.contains("email") {
-            return "Email"
-        } else if lowercaseLabel.contains("password") {
-            return "Password"
-        } else if lowercaseLabel.contains("pin") {
-            return "PIN"
-        } else if lowercaseLabel.contains("user") || lowercaseLabel.contains("id") {
-            return "User ID"
-        } else {
-            if let type = FieldType(rawValue: field.type) {
-                switch type {
-                case .username: return "User ID"
-                case .password: return "Password"
-                case .pin: return "PIN"
-                case .passphrase: return "Passphrase"
-                case .key: return "Key"
-                case .secret: return "Secret"
-                case .address: return "Address"
-                case .name: return "Name"
-                }
-            } else {
-                return ""
-            }
-        }
-    }
-    
     //show the fields
     fileprivate func displayConnectFields() {
         var previousTextField: SignUpTextField?
@@ -489,7 +457,7 @@ class SignUpViewController: NSViewController {
             textField.delegate = self
             textField.alphaValue = 0.9
             containerView.addSubview(textField)
-            textField.placeholderString = generatePlaceholder(field: field)
+            textField.placeholderString = field.name
             textField.snp.makeConstraints { make in
                 make.leading.equalToSuperview().offset(margin)
                 make.trailing.equalToSuperview().offset(-margin)

--- a/BalanceUnitTests/QRLoginCredentialsParserTests.swift
+++ b/BalanceUnitTests/QRLoginCredentialsParserTests.swift
@@ -46,14 +46,14 @@ internal final class QRLoginCredentialsParserTests: XCTestCase {
         let fields = try! self.parser.parse(value: urlString, for: .kraken)
         
         let keyField = fields.first { (field) -> Bool in
-            return field.type == "key"
+            return field.type == .key
         }
         
         XCTAssertNotNil(keyField)
         XCTAssertEqual(keyField?.value, key)
         
         let secretField = fields.first { (field) -> Bool in
-            return field.type == "secret"
+            return field.type == .secret
         }
         
         XCTAssertNotNil(secretField)
@@ -69,14 +69,14 @@ internal final class QRLoginCredentialsParserTests: XCTestCase {
         let fields = try! self.parser.parse(value: urlString, for: .bitfinex)
         
         let keyField = fields.first { (field) -> Bool in
-            return field.type == "key"
+            return field.type == .key
         }
         
         XCTAssertNotNil(keyField)
         XCTAssertEqual(keyField?.value, key)
         
         let secretField = fields.first { (field) -> Bool in
-            return field.type == "secret"
+            return field.type == .secret
         }
         
         XCTAssertNotNil(secretField)


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
#271

**What does this pull request do? What does it change?**
Sign up view now shows the correct name of each field for each institution (for example API Secret vs just Secret or whatever, so it matches the exchange websites exactly to avoid confusion)

