### PR TITLE
When main currency is set to a cryptocurrency, symbol is shown before value #341

### DIFF
--- a/Balance/Shared/View Models/AccountsTabViewModel.swift
+++ b/Balance/Shared/View Models/AccountsTabViewModel.swift
@@ -11,10 +11,7 @@ import Foundation
 class AccountsTabViewModel: TabViewModel {
     // MARK: Formatted values
     internal var formattedMasterCurrencyTotalBalance: String {
-        let totalBalance = self.totalBalance()
-        let masterCurrency = defaults.masterCurrency!
-        
-        return amountToString(amount: totalBalance, currency: masterCurrency, showNegative: true)
+        return amountToString(amount: totalBalance(), currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: true)
     }
     
     // MARK: Table Data

--- a/Balance/iOS/Views/Table View/Table View Cells/AccountTableViewCell.swift
+++ b/Balance/iOS/Views/Table View/Table View Cells/AccountTableViewCell.swift
@@ -99,12 +99,11 @@ internal final class AccountTableViewCell: TableViewCell {
         self.currencyNameLabel.text = currency.name
         
         // Amount label
-        self.amountLabel.text = amountToString(amount: unwrappedAccount.displayBalance, currency: currency)
+        self.amountLabel.text = amountToString(amount: unwrappedAccount.displayBalance, currency: currency, showNegative: true, showCodeAfterValue: true)
         
         // Detail label
-        let masterCurrency = defaults.masterCurrency!
         if let displayAltBalance = unwrappedAccount.displayAltBalance {
-            self.detailTextLabel?.text = amountToString(amount: displayAltBalance, currency: masterCurrency, showNegative: true)
+            self.detailTextLabel?.text = amountToString(amount: displayAltBalance, currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: defaults.masterCurrency.isCrypto)
             self.detailTextLabel?.isHidden = false
         } else {
             self.detailTextLabel?.isHidden = true

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/AccountsTabTableCells.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/AccountsTabTableCells.swift
@@ -199,8 +199,7 @@ class AccountsTabAccountCell: View {
         amountField.stringValue = amountToString(amount: updatedModel.displayBalance, currency: currency, showNegative: true, showCodeAfterValue: true)
         
         if let displayAltBalance = updatedModel.displayAltBalance {
-            altAmountField.stringValue = amountToString(amount: displayAltBalance, currency: defaults.masterCurrency, showNegative: true)
-            
+            altAmountField.stringValue = amountToString(amount: displayAltBalance, currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: defaults.masterCurrency.isCrypto)
             altAmountField.isHidden = false
         } else {
             altAmountField.isHidden = true


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
When main currency is set to a cryptocurrency, symbol is shown before value #341

**What does this pull request do? What does it change?**
Crypto currency conversions now show the symbol after the total, and I fixed the iOS balance total to match the style of macOS as well.

