### PR TITLE
Properly handling Coinbase token refresh errors

### DIFF
--- a/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
+++ b/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
@@ -388,19 +388,38 @@ extension CoinbaseApi {
         // TODO: Create enum types for each error
         let task = certValidatedSession.dataTask(with: request) { maybeData, maybeResponse, maybeError in
             do {
-                // Make sure there's data
-                guard let data = maybeData else {
-                    throw BalanceError.noData
-                }
-                
+                // Check for URLSession error
                 guard maybeError == nil else {
                     log.error("Failed with network error: \(String(describing: maybeError))")
                     throw BalanceError.networkError
                 }
                 
+                // Make sure there's data
+                guard let data = maybeData else {
+                    throw BalanceError.noData
+                }
+                
                 // Try to parse the JSON
-                guard let JSONResult = try JSONSerialization.jsonObject(with: data) as? [String: AnyObject], let accessToken = JSONResult["accessToken"] as? String, accessToken.count > 0, let refreshToken = JSONResult["refreshToken"] as? String, refreshToken.count > 0, let expiresIn = JSONResult["expiresIn"] as? TimeInterval else {
+                guard let JSONResult = try JSONSerialization.jsonObject(with: data) as? [String: AnyObject] else {
                     throw BalanceError.jsonDecoding
+                }
+                
+                // Check for response code
+                guard let code = JSONResult["code"] as? Int, let balanceError = BalanceError(rawValue: code) else {
+                    throw BalanceError.unexpectedData
+                }
+                
+                // Check for BalanceError
+                guard balanceError == .success else {
+                    if balanceError == .authenticationError {
+                        institution.passwordInvalid = true
+                    }
+                    throw balanceError
+                }
+                
+                // Check for expected fields
+                guard let accessToken = JSONResult["accessToken"] as? String, accessToken.count > 0, let refreshToken = JSONResult["refreshToken"] as? String, refreshToken.count > 0, let expiresIn = JSONResult["expiresIn"] as? TimeInterval else {
+                    throw BalanceError.unexpectedData
                 }
                 
                 // Update the model

--- a/Balance/Shared/Data Model/Other Models/BalanceError.swift
+++ b/Balance/Shared/Data Model/Other Models/BalanceError.swift
@@ -24,6 +24,7 @@ enum BalanceError: Int, LocalizedError {
     case noData              = 12
     case noReceipt           = 13
     case unexpectedData      = 14
+    case authenticationError = 15
     
     var errorDescription: String? {
         switch self {
@@ -42,6 +43,7 @@ enum BalanceError: Int, LocalizedError {
         case .noData:              return "No data"
         case .noReceipt:           return "No app store receipt"
         case .unexpectedData:      return "Unexpected data"
+        case .authenticationError: return "Authentication error"
         }
     }
 }


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
no

**What does this pull request do? What does it change?**
It fixes the error handling for coinbase token refreshing. We were not checking for the proper coinbase http status code and not telling the client when there was an auth error. So expired or invalid refresh tokens would forever cause a coinbase account to not refresh.

