### PR TITLE
macOS app should show price tracker on first launch #381

### DIFF
--- a/Balance/macOS/View Controllers/Main App/PopoverViewController.swift
+++ b/Balance/macOS/View Controllers/Main App/PopoverViewController.swift
@@ -23,7 +23,7 @@ class PopoverViewController: NSViewController {
 
     fileprivate(set) var currentControllerType: ContentControllerType = .none
     fileprivate var currentController: NSViewController!
-    fileprivate var tabsController = TabsViewController()
+    fileprivate var tabsController = TabsViewController(defaultTab: InstitutionRepository.si.hasInstitutions ? .accounts : .priceTicker)
     fileprivate var lockController = LockViewController()
     fileprivate var patchController: SignUpViewController?
     
@@ -66,15 +66,10 @@ class PopoverViewController: NSViewController {
             currentControllerType = .addAccount
             currentController = AddAccountViewController()
         } else {
-            if InstitutionRepository.si.hasInstitutions {
-                currentControllerType = .tabs
-                currentController = tabsController
-                if appLock.lockEnabled {
-                    appLock.locked = true
-                }
-            } else {
-                currentControllerType = .addAccount
-                currentController = AddAccountViewController()
+            currentControllerType = .tabs
+            currentController = tabsController
+            if appLock.lockEnabled {
+                appLock.locked = true
             }
         }
         


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
enhancement

**Does this pull request close an issue? If so, which one?**
#381 

**What does this pull request do? What does it change?**
When there are no institutions, it shows the price ticker on launch instead of the add account screen.

