### PR TITLE
Hide currency conversions in Transactions view since we don't show historical pricing #406

### DIFF
--- a/Balance/iOS/Views/Collection View/Cells/TransactionCollectionViewCell.swift
+++ b/Balance/iOS/Views/Collection View/Cells/TransactionCollectionViewCell.swift
@@ -9,7 +9,7 @@
 import BalanceVectorGraphics_iOS
 import UIKit
 
-
+fileprivate let hideConvertedAmounts = true
 internal final class TransactionCollectionViewCell: UICollectionViewCell, Reusable
 {
     // Static
@@ -123,6 +123,7 @@ internal final class TransactionCollectionViewCell: UICollectionViewCell, Reusab
             make.top.equalTo(self.contentView.snp.centerY).offset(2.0)
             make.right.equalToSuperview().inset(15.0)
         }
+        self.userCurrencyAmountLabel.isHidden = hideConvertedAmounts
     }
     
     internal required init?(coder aDecoder: NSCoder)
@@ -153,12 +154,14 @@ internal final class TransactionCollectionViewCell: UICollectionViewCell, Reusab
         self.amountLabel.text = amountToString(amount: unwrappedTransaction.amount, currency: currency)
         
         // User currency amount
-        let masterCurrency = defaults.masterCurrency!
-        if let masterAmount = unwrappedTransaction.masterAltAmount {
-            self.userCurrencyAmountLabel.text = amountToString(amount: masterAmount, currency: masterCurrency, showNegative: true)
-            self.userCurrencyAmountLabel.isHidden = false
-        } else {
-            self.userCurrencyAmountLabel.isHidden = true
+        if !hideConvertedAmounts {
+            let masterCurrency = defaults.masterCurrency!
+            if let masterAmount = unwrappedTransaction.masterAltAmount {
+                self.userCurrencyAmountLabel.text = amountToString(amount: masterAmount, currency: masterCurrency, showNegative: true)
+                self.userCurrencyAmountLabel.isHidden = false
+            } else {
+                self.userCurrencyAmountLabel.isHidden = true
+            }
         }
         
         // Transaction type

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/TransactionsTabTableCells.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/TransactionsTabTableCells.swift
@@ -68,6 +68,7 @@ fileprivate class NoHitMapView: MKMapView {
     }
 }
 
+fileprivate let hideConvertedAmounts = true
 class TransactionsTabTransactionCell: View {
     var model: Transaction?
     var index = TableIndex.none
@@ -170,6 +171,7 @@ class TransactionsTabTransactionCell: View {
             make.right.equalToSuperview().offset(-10)
             make.bottom.equalToSuperview().offset(-17)
         }
+        altAmountField.isHidden = hideConvertedAmounts
         
         NotificationCenter.addObserverOnMainThread(self, selector: #selector(cellOpened(_:)), name: TransactionsTabViewController.InternalNotifications.CellOpened)
         NotificationCenter.addObserverOnMainThread(self, selector: #selector(cellClosed(_:)), name: TransactionsTabViewController.InternalNotifications.CellClosed)
@@ -202,10 +204,12 @@ class TransactionsTabTransactionCell: View {
         
         institutionNameField.stringValue = updatedModel.institution?.name ?? ""
         
-        if let displayAltAmount = updatedModel.displayAltAmount {
-            altAmountField.stringValue = amountToString(amount: displayAltAmount, currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: true)
-        } else {
-            altAmountField.stringValue = ""
+        if !hideConvertedAmounts {
+            if let displayAltAmount = updatedModel.displayAltAmount {
+                altAmountField.stringValue = amountToString(amount: displayAltAmount, currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: true)
+            } else {
+                altAmountField.stringValue = ""
+            }
         }
         
         self.toolTip = DateFormatter.localizedString(from: updatedModel.date, dateStyle: .medium, timeStyle: .medium)


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
task

**Does this pull request close an issue? If so, which one?**
#406 

**What does this pull request do? What does it change?**
Hide currency conversions in Transactions view since we don't show historical pricing. We'll re-enable in a 1.0.x release when we have a historical pricing data API.

