### PR TITLE
Fixed Ethplorer accounts show again after hiding them

### DIFF
--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerApi.swift
@@ -236,12 +236,6 @@ class EthplorerApi: ExchangeApi {
     @discardableResult func updateLocalAccount(institution: Institution) -> Account? {
         // Calculate the integer value of the balance based on the decimals
         if let newAccount = AccountRepository.si.account(institutionId: institution.institutionId, source: institution.source, sourceAccountId: currency.code, sourceInstitutionId: "", accountTypeId: .wallet, accountSubTypeId: nil, name: currency.name, currency: currency.code, currentBalance: balance, availableBalance: nil, number: nil, altCurrency: altCurrency?.code, altCurrentBalance: altBalance, altAvailableBalance: nil) {
-            
-            // Hide unpoplular currencies that have a 0 balance
-            if currency != Currency.btc && currency != Currency.eth {
-                newAccount.isHidden = (balance == 0)
-            }
-            
             return newAccount
         }
         return nil


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
no

**What does this pull request do? What does it change?**
We had this logic to hide empty accounts, but ethplorer api already does not return them so all it does is show accounts you’ve hidden.

