### PR TITLE
Fix crash when remove an exchange account

### DIFF
--- a/Balance/Shared/View Models/AccountsTabViewModel.swift
+++ b/Balance/Shared/View Models/AccountsTabViewModel.swift
@@ -64,6 +64,22 @@ class AccountsTabViewModel: TabViewModel {
         persistSortOrder()
     }
     
+    func removeInstitution(at index: Int) -> Bool {
+        guard let institution = institution(forSection: index) else {
+            log.error("Cant delete a row without an institution")
+            return false
+        }
+        
+        guard institution.delete() else {
+            log.error("Intitution with \(institution.institutionId) id, can't be deleted")
+            return false
+        }
+        
+        institutionRemoved(institution: institution)
+        
+        return true
+    }
+    
     func institutionRemoved(institution: Institution) {
         var newData = data
         newData[institution] = nil

--- a/Balance/iOS/View Controllers/Settings/SettingsViewController.swift
+++ b/Balance/iOS/View Controllers/Settings/SettingsViewController.swift
@@ -155,12 +155,8 @@ internal final class SettingsViewController: UIViewController
                 self.navigationController?.pushViewController(institutionSettingsViewController, animated: true)
             }
             
-            row.deletionHandler = { [unowned self] (indexPath) in
-                if institution.delete()
-                {
-                    self.reloadData()
-                    self.tableView.deleteRows(at: [indexPath], with: .automatic)
-                }
+            row.deletionHandler = { [weak self] (indexPath) in
+                self?.deleteAccount(at: indexPath)
             }
             
             institutionRows.append(row)
@@ -212,6 +208,18 @@ internal final class SettingsViewController: UIViewController
     @objc private func accountRemovedNotification(_ notification: Notification) {
         self.reloadData()
         self.tableView.reloadData()
+    }
+    
+    private func deleteAccount(at indexPath: IndexPath) {
+        guard viewModel.removeInstitution(at: indexPath.row) else {
+            log.error("Cant delete intitution for indexpath \(indexPath)")
+            return
+        }
+        
+        var sectionData = self.tableData[indexPath.section]
+        sectionData.rows.remove(at: indexPath.row)
+        tableData[indexPath.section] = sectionData
+        tableView.deleteRows(at: [indexPath], with: .automatic)
     }
 }
 

--- a/Balance/iOS/Views/Table View/Table View Cells/TableData.swift
+++ b/Balance/iOS/Views/Table View/Table View Cells/TableData.swift
@@ -14,7 +14,7 @@ import UIKit
 internal struct TableSection
 {
     let title: String?
-    let rows: [TableRow]
+    var rows: [TableRow]
 }
 
 


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
This pr solves a crash.

**Does this pull request close an issue? If so, which one?**
No, issue was discovered

**What does this pull request do? What does it change?**
When user deletes an account, table view crash when compare the elements before and after the deletion animation

  