### PR TITLE
Bug/380/multiple credentials

### DIFF
--- a/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
+++ b/Balance/Shared/Data Model/Bitfinex/BitfinexAPIClient.swift
@@ -207,7 +207,7 @@ extension BitfinexAPIClient: ExchangeApi {
     func authenticate(secret: String, key: String, passphrase: String) {
         assert(false, "implement")
     }
-    
+
     func authenticationChallenge(loginStrings: [Field], existingInstitution: Institution? = nil, closeBlock: @escaping (Bool, Error?, Institution?) -> Void) {
         assert(loginStrings.count == 2, "number of auth fields should be 2 for Bitfinex")
         
@@ -242,11 +242,9 @@ extension BitfinexAPIClient: ExchangeApi {
             try self.fetchWallets { _, error in
                 guard let unwrappedError = error else {
                     do {
-                        let credentialsIdentifier = "main"
-                        try credentials.save(identifier: credentialsIdentifier)
-                        
                         if let existingInstitution = existingInstitution {
-                            existingInstitution.accessToken = credentialsIdentifier
+                            try credentials.save(identifier: "\(existingInstitution.institutionId)")
+                            existingInstitution.accessToken = "\(existingInstitution.institutionId)"
                             async {
                                 closeBlock(true, error, existingInstitution)
                             }
@@ -257,7 +255,7 @@ extension BitfinexAPIClient: ExchangeApi {
                                 }
                                 return
                             }
-                            institution.accessToken = credentialsIdentifier
+                            institution.accessToken = "\(institution.institutionId)"
                             
                             try self.fetchWallets({ (wallets, error) in
                                 guard let unwrappedWallets = wallets else {

--- a/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/TransactionsTabTableCells.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/Table Cells/TransactionsTabTableCells.swift
@@ -280,8 +280,8 @@ class TransactionsTabTransactionCell: View {
             make.top.equalTo(institutionField.snp.bottom)
         }
         
-        institutionField.stringValue = model.institution!.name
-        accountField.stringValue = model.account!.name
+        institutionField.stringValue = model.institution?.name ?? ""
+        accountField.stringValue = model.account?.name ?? ""
     }
     
     func unloadBottomContainer() {


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
First a bug on transactions that would make the app crash
Second the hability to add mutiple bitfinex accounts (so basically without this change every account added will be overwritten on the keychain credentials)

**Does this pull request close an issue? If so, which one?**
#380 



