### PR TITLE
Fixed Prices tab doesn’t set a window height

### DIFF
--- a/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/PriceTickerTabViewController.swift
@@ -47,6 +47,10 @@ class PriceTickerTabViewController: NSViewController, SectionedTableViewDelegate
     override func viewWillAppear() {
         super.viewWillAppear()
         
+        async {
+            AppDelegate.sharedInstance.resizeWindowToMaxHeight(animated: true)
+        }
+        
         reloadData()
     }
     


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
#336

**What does this pull request do? What does it change?**
Prices tab didn't resize automatically, it used the last tab's height

