### PR TITLE
Remove elasticity from the cards in accounts view

### DIFF
--- a/Balance/iOS/Views/Collection View/Layouts/StackedLayout.swift
+++ b/Balance/iOS/Views/Collection View/Layouts/StackedLayout.swift
@@ -18,7 +18,7 @@ internal final class StackedLayout: UICollectionViewLayout {
     internal weak var delegate: StackedLayoutDelegate?
     
     // Private
-    private let stretchValue: CGFloat = 0.2
+    private let stretchValue: CGFloat = 0
     private let itemOverlap: CGFloat = 40.0
     private var layoutAttributes = [IndexPath : UICollectionViewLayoutAttributes]()
     private var previousLayoutAttributes = [IndexPath : UICollectionViewLayoutAttributes]()


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
This pr is not a real fix only avoid a behavior

**Does this pull request close an issue? If so, which one?**
#443 

**What does this pull request do? What does it change?**
When the user do a pull down to refresh, this action adds an space between them, i only removed the space and let the cells be stick together as they are.