### PR TITLE
AUto sync when we enter the screen

### DIFF
--- a/Balance/iOS/View Controllers/Accounts list/AccountsListViewController.swift
+++ b/Balance/iOS/View Controllers/Accounts list/AccountsListViewController.swift
@@ -136,12 +136,17 @@ internal final class AccountsListViewController: UIViewController {
         
         navigationController?.isNavigationBarHidden = true
         UIApplication.shared.statusBarStyle = .lightContent
-        
-        reloadData()
-
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             self?.presentReconnectViewIfNeeded()
         }
+        syncManager.sync(userInitiated: true, validateReceipt: true) { (success, _) in
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reloadData()
+        
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -162,10 +167,10 @@ internal final class AccountsListViewController: UIViewController {
     
     private func reloadData() {
         self.viewModel.reloadData()
+        let accountsNotEmpty = self.viewModel.numberOfSections() > 0
         self.collectionView.reloadData(shouldPersistSelection: true, with: viewModel.selectedCardIndexes)
-        
-        self.blankStateView.isHidden = viewModel.numberOfSections() > 0
-        self.totalBalanceBar.isHidden = !blankStateView.isHidden
+        self.blankStateView.isHidden = accountsNotEmpty
+        self.totalBalanceBar.isHidden = !accountsNotEmpty
         
         self.totalBalanceBar.totalBalanceLabel.text = viewModel.formattedMasterCurrencyTotalBalance
     }


### PR DESCRIPTION
Also tweaked a bit how we do the sync

**Does this pull request close an issue? If so, which one?**
#476 #489 

**What does this pull request do? What does it change?**
It removes the ReloadData from view will appear since it blocks the app when switching tabs.
It also adds a fetch of new data when the view is about to show (so every time we get to that screen we reload any data, and avoid misleading users).

NOTE: this doesn't fix the fact that when we refresh that screen we are blocking heavily main thread, you can see this if you switch tabs and play with the UI as it will stop scrolling. This PR doesn't fix the blocking of main thread (This probably happens on sync or on refresh somehow, since we don't do smart updates on the cells but refresh the hole table). I suggest @Rolvar  to take a look on the blocking main thread issues if he has time

