### PR TITLE
Bug/496/coinbase refreshtoken ios

### DIFF
--- a/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
+++ b/Balance/Shared/Data Model/APIs/Coinbase/CoinbaseApi.swift
@@ -15,7 +15,6 @@
 typealias SuccessErrorBlock = (_ success: Bool, _ error: Error?) -> Void
 
 fileprivate let cbVersion = "2017-05-19"
-fileprivate let connectionTimeout = 30.0
 fileprivate let subServerUrl = debugging.useLocalSubscriptionServer ? "http://localhost:8080/" : "https://api.balancemy.money/"
 fileprivate let clientId = "a6e15fbb0c3362b74360895f261fb079672c10eef79dcb72308c974408c5ce43"
 
@@ -73,7 +72,6 @@ struct CoinbaseApi: ExchangeApi {
         let urlString = "\(subServerUrl)coinbase/requestToken"
         let url = URL(string: urlString)!
         var request = URLRequest(url: url)
-        request.timeoutInterval = connectionTimeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.POST
         let parameters = "{\"code\":\"\(code)\"}"
@@ -149,7 +147,6 @@ struct CoinbaseApi: ExchangeApi {
         let urlString = "https://api.coinbase.com/v2/accounts"
         let url = URL(string: urlString)!
         var request = URLRequest(url: url)
-        request.timeoutInterval = connectionTimeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.GET
         request.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
@@ -219,7 +216,6 @@ struct CoinbaseApi: ExchangeApi {
         let urlString = "https://api.coinbase.com/v2/accounts/\(accountID)/transactions"
         let url = URL(string: urlString)!
         var request = URLRequest(url: url)
-        request.timeoutInterval = connectionTimeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.GET
         request.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
@@ -396,7 +392,6 @@ extension CoinbaseApi {
         let urlString = "\(subServerUrl)coinbase/refreshToken"
         let url = URL(string: urlString)!
         var request = URLRequest(url: url)
-        request.timeoutInterval = connectionTimeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.POST
         let parameters = "{\"refreshToken\":\"\(refreshToken)\"}"

--- a/Balance/Shared/Data Model/Syncing/SyncManager.swift
+++ b/Balance/Shared/Data Model/Syncing/SyncManager.swift
@@ -88,16 +88,16 @@ class SyncManager: NSObject {
         }
     }
     
-    func sync(userInitiated: Bool = false, validateReceipt: Bool = true, completion: SuccessErrorsHandler? = nil) {
+    func sync(userInitiated: Bool = false, validateReceipt: Bool = true, skip: [Source] = [.coinbase], completion: SuccessErrorsHandler? = nil) {
         guard !syncer.syncing && networkStatus.isReachable && Thread.isMainThread else {
             completion?(true, [])
             return
         }
         
-        performSync(userInitiated: userInitiated, completion: completion)
+        performSync(userInitiated: userInitiated, skip: skip, completion: completion)
     }
     
-    fileprivate func performSync(userInitiated: Bool = false, completion: SuccessErrorsHandler? = nil) {
+    private func performSync(userInitiated: Bool = false, skip: [Source] = [], completion: SuccessErrorsHandler? = nil) {
         // Cancel any automatic runs of this method in case it's called manually
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.automaticSync), object: nil)
        
@@ -114,7 +114,7 @@ class SyncManager: NSObject {
         // Start the sync
         log.debug("Performing full sync")
         self.syncer = debugging.useMockSyncing ? MockSyncer() : Syncer()
-        self.syncer.sync(startDate: Date(timeIntervalSinceNow: -tenYears), pruneTransactions: true) { success, errors in
+        self.syncer.sync(startDate: Date(timeIntervalSinceNow: -tenYears), pruneTransactions: true, skip: skip) { success, errors in
             // Set the last sync dates, record all syncs using the lastSyncTime keys for ease of use then record full syncs separately
             let now = Date()
             self.syncDefaults.lastSyncTime = now

--- a/Balance/Shared/Data Model/Syncing/Syncer.swift
+++ b/Balance/Shared/Data Model/Syncing/Syncer.swift
@@ -22,7 +22,7 @@ class Syncer {
         canceled = true
     }
     
-    func sync(startDate: Date, pruneTransactions: Bool = false, completion: SuccessErrorsHandler?) {
+    func sync(startDate: Date, pruneTransactions: Bool = false, skip: [Source] = [], completion: SuccessErrorsHandler?) {
         guard !syncing else {
             return
         }
@@ -36,7 +36,9 @@ class Syncer {
         if InstitutionRepository.si.institutionsCount > 0 {
             // Grab the institutions again in case we've added one while syncing categories or we've been canceled
             // and sort them as they're displayed in the UI
-            let institutions = InstitutionRepository.si.allInstitutions(sorted: true)
+            let institutions = InstitutionRepository.si.allInstitutions(sorted: true).filter { institution -> Bool in
+                return !skip.contains(institution.source)
+            }
             
             let success = true
             let errors = [Error]()
@@ -555,7 +557,7 @@ class Syncer {
 }
 
 class MockSyncer: Syncer {
-    override func sync(startDate: Date, pruneTransactions: Bool, completion: SuccessErrorsHandler?) {
+    override func sync(startDate: Date, pruneTransactions: Bool, skip: [Source] = [], completion: SuccessErrorsHandler?) {
         guard !syncing else {
             return
         }

--- a/Balance/iOS/AppDelegate.swift
+++ b/Balance/iOS/AppDelegate.swift
@@ -167,7 +167,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
     {
-        syncManager.sync(userInitiated: false, validateReceipt: false) { (success, error) in
+        syncManager.sync(userInitiated: false, validateReceipt: false, skip: [.coinbase]) { (success, error) in
             let result: UIBackgroundFetchResult = success ? .newData : .failed
             completionHandler(result)
         }


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Coinbase keeps somehow getting set to password invalid #496

**What does this pull request do? What does it change?**
Turns off Coinbase syncing in background app refresh because it times out and loses the token. Also increased the timeout for Coinbase calls during normal app usage to the default to reduce the chances of it happening then too.

