### PR TITLE
Update Bittrex balance model to handle edge cases.

### DIFF
--- a/Balance/Shared/Data Model/APIs/BITTREX/DTO/BITTREXBalance.swift
+++ b/Balance/Shared/Data Model/APIs/BITTREX/DTO/BITTREXBalance.swift
@@ -14,8 +14,8 @@ struct BITTREXBalance: Codable {
     let balance: Double
     let available: Double
     let pending: Double
-    let cryptoAddress: String
-    let requested: Bool
+    let cryptoAddress: String?
+    let requested: Bool?
     let uuid: String?
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
This PR fixes the issue caused by unexpected missing fields in Bittrex balance API endpoint response.

Note: 
- `cryptoAddress` could be missing due to several reasons, one of the top reasons is the currency is under maintenance on Bittrex.
- I never got `requested` back from the response, though Bittrex API doc said it should be included.