### PR TITLE
Loading spinner on ios

### DIFF
--- a/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
+++ b/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
@@ -134,6 +134,11 @@ internal final class AccountsListViewController: UIViewController {
         }
         
         registerForNotifications()
+        
+        self.collectionView.setContentOffset(CGPoint(x: 0, y: -1.0), animated: false);
+        self.collectionView.setContentOffset(CGPoint(x: 0, y: -self.refreshControl.frame.size.height), animated: true)
+        self.refreshControl.beginRefreshing()
+
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
+++ b/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
@@ -119,6 +119,10 @@ internal final class AccountsListViewController: UIViewController {
         
         view.bringSubview(toFront: titleLabel)
         view.bringSubview(toFront: headerAddAcountButton)
+        
+        self.collectionView.setContentOffset(CGPoint(x: 0, y: -1.0), animated: false);
+        self.collectionView.setContentOffset(CGPoint(x: 0, y: -self.refreshControl.frame.size.height), animated: true)
+        self.refreshControl.beginRefreshing()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -134,11 +138,6 @@ internal final class AccountsListViewController: UIViewController {
         }
         
         registerForNotifications()
-        
-        self.collectionView.setContentOffset(CGPoint(x: 0, y: -1.0), animated: false);
-        self.collectionView.setContentOffset(CGPoint(x: 0, y: -self.refreshControl.frame.size.height), animated: true)
-        self.refreshControl.beginRefreshing()
-
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Forcing reload of the tab every time we enter the app (that is even when app opens)
Why? because syncing process starts after we have loaded the view, therefore we can't trust the syncer state.
Instead of adding a loading to the bar I just scroll the UI as if user pulled to show it's refreshing (it ends when syncer normally ends)
**Does this pull request close an issue? If so, which one?**
#508 


