### PR TITLE
Last card on iOS should close all the way #509

### DIFF
--- a/Balance/Shared/View Models/AccountsTabViewModel.swift
+++ b/Balance/Shared/View Models/AccountsTabViewModel.swift
@@ -126,6 +126,10 @@ class AccountsTabViewModel: TabViewModel {
         return 0
     }
     
+    func isLastSection(_ section: Int) -> Bool {
+        return section == numberOfSections() - 1
+    }
+    
     func isLastRow(_ row: Int, inSection section: Int) -> Bool {
         return row == numberOfRows(inSection: section) - 1
     }

--- a/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
+++ b/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
@@ -321,7 +321,9 @@ extension AccountsListViewController: StackedLayoutDelegate {
         let measurementCell = InstitutionCollectionViewCell.measurementCell
         measurementCell.viewModel = InstitutionAccountsListViewModel(institution: institution)
         
-        return measurementCell.closedContentHeight
+        // NOTE: It's unintuitive but in the iOS implementation, the table has only one actual section with tables inside the cards,
+        // so in this case, the row of the indexPath in the collection view is the section
+        return viewModel.isLastSection(indexPath.row) ? measurementCell.closedContentHeight - 40 : measurementCell.closedContentHeight
     }
     
     func expandedHeightForItem(at indexPath: IndexPath, in collectionView: UICollectionView) -> CGFloat {

--- a/Balance/iOS/Views/Collection View/Cells/InstitutionCollectionViewCell.swift
+++ b/Balance/iOS/Views/Collection View/Cells/InstitutionCollectionViewCell.swift
@@ -34,7 +34,7 @@ internal final class InstitutionCollectionViewCell: UICollectionViewCell, Reusab
     internal private(set) var expandedContentHeight: CGFloat = 0.0
     
     internal var closedContentHeight: CGFloat {
-        return 100.0
+        return 99.0
     }
     
     // Private


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Last card on iOS should close all the way #509

**What does this pull request do? What does it change?**
The last card now closes completely instead of showing part of it's first row.
Also fixed that the other cards show their first separator when closed
