### PR TITLE
Old log files should be purged when logs reach a certain size #538

### DIFF
--- a/Balance/Shared/Data Model/Singleton/Feedback.swift
+++ b/Balance/Shared/Data Model/Singleton/Feedback.swift
@@ -30,7 +30,7 @@ struct Feedback {
             dict["source"] = apiInstitution?.source.rawValue
             dict["sourceInstitutionId"] = apiInstitution?.sourceInstitutionId
             dict["institutionName"] = apiInstitution?.name
-            if let logsZipUrl = logging.zipLogFiles(), let logsData = try? Data(contentsOf: logsZipUrl), logsData.count < 2 * 1024 * 1024 {
+            if let logsZipUrl = logging.zipLogFiles(), let logsData = try? Data(contentsOf: logsZipUrl) {
                 dict["logs"] = logsData.base64EncodedString()
             }
             


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Old log files should be purged when logs reach a certain size #538

**What does this pull request do? What does it change?**
Keeps total log file size under ~3.5MB so that it zips to a max of ~500KB. Also no longer using a limit check on the logs zip when sending feedback as log purging will always keep it under that size, and if it’s over that size it means they had a reeeeeeeeeeeeeeally long session and we want that log anyway.

