### PR TITLE
Fixes display logic for reconnect dialog on iOS

### DIFF
--- a/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
+++ b/Balance/iOS/View Controllers/Tabs/AccountsListViewController.swift
@@ -133,10 +133,6 @@ final class AccountsListViewController: UIViewController {
         
         reloadData()
         
-        async(after: 1.0) {
-            self.presentReconnectViewIfNeeded()
-        }
-        
         registerForNotifications()
         
         if syncManager.syncing {
@@ -243,6 +239,10 @@ final class AccountsListViewController: UIViewController {
         
         if !syncManager.syncing {
             refreshControl.endRefreshing()
+        }
+        
+        async(after: 0.1) {
+            self.presentReconnectViewIfNeeded()
         }
     }
     


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
no

**What does this pull request do? What does it change?**
Now it shows after every sync not just on view will appear and decreases the delay time


