### PR TITLE
No transactions for Ethplorer wallets #549

### DIFF
--- a/Balance.xcodeproj/project.pbxproj
+++ b/Balance.xcodeproj/project.pbxproj
@@ -239,6 +239,8 @@
 		53629D54201FE85B000081E9 /* TabButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53629D4E201FE85A000081E9 /* TabButtons.swift */; };
 		53629D55201FE85B000081E9 /* AccountConnectionErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53629D4F201FE85A000081E9 /* AccountConnectionErrors.swift */; };
 		53629D5820238AF9000081E9 /* EmailIssueController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53629D5720238AF9000081E9 /* EmailIssueController.swift */; };
+		53629D5A20240F48000081E9 /* EthplorerTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53629D5920240F48000081E9 /* EthplorerTransaction.swift */; };
+		53629D5B20240F48000081E9 /* EthplorerTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53629D5920240F48000081E9 /* EthplorerTransaction.swift */; };
 		536C6EEF1D864C9B00823688 /* MockedDefaultsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536C6EEE1D864C9B00823688 /* MockedDefaultsStorage.swift */; };
 		536C6EF21D864CB900823688 /* DefaultsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536C6EF11D864CB900823688 /* DefaultsStorage.swift */; };
 		537187DC1F4CC23B00E7F9D6 /* CoinbaseApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538B47B11F4C9FD60023CED5 /* CoinbaseApi.swift */; };
@@ -790,6 +792,7 @@
 		53629D4E201FE85A000081E9 /* TabButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabButtons.swift; sourceTree = "<group>"; };
 		53629D4F201FE85A000081E9 /* AccountConnectionErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountConnectionErrors.swift; sourceTree = "<group>"; };
 		53629D5720238AF9000081E9 /* EmailIssueController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailIssueController.swift; sourceTree = "<group>"; };
+		53629D5920240F48000081E9 /* EthplorerTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthplorerTransaction.swift; sourceTree = "<group>"; };
 		536C6EEE1D864C9B00823688 /* MockedDefaultsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockedDefaultsStorage.swift; sourceTree = "<group>"; };
 		536C6EF11D864CB900823688 /* DefaultsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultsStorage.swift; sourceTree = "<group>"; };
 		537187F21F4CC2FB00E7F9D6 /* NumberUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberUtils.swift; sourceTree = "<group>"; };
@@ -2209,6 +2212,7 @@
 				A4E457101F7901DD002E2879 /* EthplorerApi.swift */,
 				A4E457111F7901DD002E2879 /* EthplorerErrors.swift */,
 				A4E457121F7901DD002E2879 /* EthplorerInstitution.swift */,
+				53629D5920240F48000081E9 /* EthplorerTransaction.swift */,
 			);
 			name = Ethplorer;
 			path = APIs/Ethplorer;
@@ -2847,6 +2851,7 @@
 				53552A1B1ED7251700DD95F9 /* Transaction.swift in Sources */,
 				2DFB60012020CA3D00C4B817 /* BtcApi.swift in Sources */,
 				A4E4571A1F7901E7002E2879 /* EthplorerInstitution.swift in Sources */,
+				53629D5B20240F48000081E9 /* EthplorerTransaction.swift in Sources */,
 				53552A091ED7251200DD95F9 /* Defaults.swift in Sources */,
 				537187DD1F4CC23B00E7F9D6 /* CoinbaseAccount.swift in Sources */,
 				A42953D41F8E255D00729045 /* InstitutionCollectionViewCell.swift in Sources */,
@@ -3117,6 +3122,7 @@
 				537187FD1F4CC43000E7F9D6 /* SignUpViewController.swift in Sources */,
 				53D441EC1F44B224006967E1 /* FMDatabasePoolAdditions.m in Sources */,
 				530F57991DCD72680083F3A7 /* FMDatabase.m in Sources */,
+				53629D5A20240F48000081E9 /* EthplorerTransaction.swift in Sources */,
 				F1253E5E1D75D2D0001BD48C /* KeychainManager.swift in Sources */,
 				53C197171CB8714100F0A47B /* SyncManager.swift in Sources */,
 				28A0DC131DCD010800601E87 /* ChangePasswordViewController.swift in Sources */,

--- a/Balance.xcodeproj/project.pbxproj
+++ b/Balance.xcodeproj/project.pbxproj
@@ -3952,7 +3952,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BalanceOpen.app/Contents/MacOS/BalanceOpen";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Balance.app/Contents/MacOS/Balance";
 			};
 			name = Debug;
 		};
@@ -3983,7 +3983,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BalanceOpen.app/Contents/MacOS/BalanceOpen";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Balance.app/Contents/MacOS/Balance";
 			};
 			name = UITesting;
 		};
@@ -4013,7 +4013,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BalanceOpen.app/Contents/MacOS/BalanceOpen";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Balance.app/Contents/MacOS/Balance";
 			};
 			name = Release;
 		};

--- a/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerTransaction.swift
+++ b/Balance/Shared/Data Model/APIs/Ethplorer/EthplorerTransaction.swift
@@ -1,0 +1,19 @@
+//
+//  EthplorerTransaction.swift
+//  Balance
+//
+//  Created by Benjamin Baron on 2/1/18.
+//  Copyright © 2018 Balanced Software, Inc. All rights reserved.
+//
+
+import Foundation
+
+struct EthplorerTransaction: Codable {
+    let timestamp: Int
+    let from: String?
+    let to: String?
+    let hash: String
+    let value: Double
+    let input: String
+    let success: Bool
+}

--- a/Balance/Shared/Data Model/Singleton/CertValidator.m
+++ b/Balance/Shared/Data Model/Singleton/CertValidator.m
@@ -40,6 +40,10 @@ const NSString *globalSign                              = @"7HIpactkIAq2Y49orFOO
 const NSString *COMODOECCCertificationAuthority         = @"58qRu/uxh4gFezqAcERupSkRYBlBAvfcw7mEjGPLnNU="; // COMODO ECC Certification Authority (note this uses kTSKAlgorithmEcDsaSecp384r1)
 const NSString *COMODOECCDomainValidationSecureServerCA = @"EohwrK1N7rr3bRQphPj4j2cel+B2d0NNbM9PWHNDXpM="; // COMODO ECC Domain Validation Secure Server CA 2 (note this uses kTSKAlgorithmEcDsaSecp256r1)
 
+// Comodo RSA
+const NSString *COMODORSADomainValidationSecureServerCA = @"klO23nT2ehFDXCfx3eHTDRESMz3asj1muO+4aIdjiuY="; // COMODO RSA Domain Validation Secure Server CA
+const NSString *COMODORSACertificationAuthority         = @"grX4Ta9HpZx6tSHkmCrvpApTQGo67CYDnvprLg5yRME="; // COMODO RSA Certification Authority (note this uses kTSKAlgorithmRsa4096)
+
 @implementation CertValidator
     
 - (instancetype)init {
@@ -108,6 +112,18 @@ const NSString *COMODOECCDomainValidationSecureServerCA = @"EohwrK1N7rr3bRQphPj4
                           kTSKEnforcePinning : @YES,
                           kTSKPublicKeyAlgorithms : @[kTSKAlgorithmEcDsaSecp384r1, kTSKAlgorithmEcDsaSecp256r1],
                           kTSKPublicKeyHashes : @[COMODOECCDomainValidationSecureServerCA, COMODOECCCertificationAuthority],
+                          kTSKReportUris : @[balanceReportUri]
+                          },
+                  @"bittrex.com" : @{
+                          kTSKEnforcePinning : @YES,
+                          kTSKPublicKeyAlgorithms : @[kTSKAlgorithmEcDsaSecp384r1, kTSKAlgorithmEcDsaSecp256r1],
+                          kTSKPublicKeyHashes : @[COMODOECCDomainValidationSecureServerCA, COMODOECCCertificationAuthority],
+                          kTSKReportUris : @[balanceReportUri]
+                          },
+                  @"api.ethplorer.io" : @{
+                          kTSKEnforcePinning : @YES,
+                          kTSKPublicKeyAlgorithms : @[kTSKAlgorithmRsa2048, kTSKAlgorithmRsa4096],
+                          kTSKPublicKeyHashes : @[COMODORSADomainValidationSecureServerCA, COMODORSACertificationAuthority],
                           kTSKReportUris : @[balanceReportUri]
                           }
                   }};

--- a/Balance/Shared/Data Model/Syncing/Syncer.swift
+++ b/Balance/Shared/Data Model/Syncing/Syncer.swift
@@ -546,7 +546,7 @@ class Syncer {
         
         //sync Ethplore
         let ethploreApi = EthplorerApi(name: "", address: address)
-        ethploreApi.fetchAddressInfo(institution: institution, completion: { (success, error) in
+        ethploreApi.fetchAddressInfo(institution: institution) { success, error in
             if !success {
                 syncingSuccess = false
                 if let error = error {
@@ -559,8 +559,19 @@ class Syncer {
                 self.cancelSync(errors: syncingErrors)
                 return
             }
-            self.syncInstitutions(remainingInstitutions, startDate: startDate, success: syncingSuccess, errors: syncingErrors)
-        })
+            
+            ethploreApi.fetchTransactionInfo(institution: institution) { success, error in
+                if !success {
+                    syncingSuccess = false
+                    if let error = error {
+                        syncingErrors.append(error)
+                        log.error("Error pulling transactions for \(institution): \(error)")
+                    }
+                }
+                
+                self.syncInstitutions(remainingInstitutions, startDate: startDate, success: syncingSuccess, errors: syncingErrors)
+            }
+        }
     }
     
     fileprivate func cancelSync(errors: [Error]) {


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
No transactions for Ethplorer wallets #549

**What does this pull request do? What does it change?**
Adds transaction parsing (only ETH and only the last 50 transactions, tokens don't seem to work on ethplorer's api). Also adds cert validation for ethplorer and bittrex (tested both).

