### PR TITLE
Fixed crash when hitting tab key, it now cycles through the tabs

### DIFF
--- a/Balance/macOS/View Controllers/Tabs/View Controllers/TabsViewController.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/TabsViewController.swift
@@ -392,6 +392,7 @@ class TabsViewController: NSViewController {
                     }
                 }
                 
+                let tabButtonKeyCode = 48
                 if !appLock.locked && event.window == self.view.window {
                     if let characters = event.charactersIgnoringModifiers {
                         if event.modifierFlags.contains(NSEvent.ModifierFlags.command) && characters.count == 1 {
@@ -411,6 +412,14 @@ class TabsViewController: NSViewController {
                             } else if characters == "h" {
                                 NotificationCenter.postOnMainThread(name: Notifications.HidePopover)
                             }
+                        } else if event.keyCode == tabButtonKeyCode {
+                            // Cycle through the tabs
+                            var tabIndex = self.currentVisibleTab.rawValue + 1
+                            if tabIndex >= self.tabButtons.count {
+                                tabIndex = 0
+                            }
+                            self.showTab(tabIndex: tabIndex)
+                            return nil
                         }
                     }
                 }


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
weird crash in latest macOS (balance-v1.0-beta1) #506

**What does this pull request do? What does it change?**
Tab key now cycles through tabs instead of crashing

