### PR TITLE
Bug/210/find similar crash

### DIFF
--- a/Balance/macOS/View Controllers/Tabs/Views/TransactionContextMenu.swift
+++ b/Balance/macOS/View Controllers/Tabs/Views/TransactionContextMenu.swift
@@ -56,14 +56,7 @@ class TransactionContextMenu: NSObject, NSMenuDelegate {
     @objc fileprivate func copyTransactionToClipboard() {
         let name = transaction.displayName
         let amount = amountToString(amount: transaction.amount, currency: Currency.rawValue(transaction.currency), showNegative: false, showCodeAfterValue: true)
-        var altAmount: String? = nil
-        if let displayAltAmount = transaction.displayAltAmount {
-            altAmount = amountToString(amount: displayAltAmount, currency: defaults.masterCurrency, showNegative: true, showCodeAfterValue: true)
-        }
-        var finalString = "\(name) \(amount)"
-        if let altAmount = altAmount {
-            finalString += " (\(altAmount))"
-        }
+        let finalString = "\(name) \(amount)"
         
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(finalString, forType: .string)

--- a/Balance/macOS/View Controllers/Tabs/Views/TransactionContextMenu.swift
+++ b/Balance/macOS/View Controllers/Tabs/Views/TransactionContextMenu.swift
@@ -24,9 +24,7 @@ class TransactionContextMenu: NSObject, NSMenuDelegate {
     }
     
     static func showMenu(transaction: Transaction, view: NSView) {
-        var items = [NSMenuItem(title: "Find Similar Transactions", action: #selector(searchTransactionsAction), keyEquivalent: ""),
-                     NSMenuItem.separator(),
-                     NSMenuItem(title: "Copy Transaction", action: #selector(copyTransactionToClipboard), keyEquivalent: ""),
+        var items = [NSMenuItem(title: "Copy Transaction", action: #selector(copyTransactionToClipboard), keyEquivalent: ""),
                      NSMenuItem(title: "Copy Transaction ID", action: #selector(copyTransactionIdToClipboard), keyEquivalent: ""),
                      NSMenuItem(title: "Copy Amount", action: #selector(copyAmountToClipboard), keyEquivalent: "")]
         


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
Crash on control-Click > Find Similar Transactions #210

**What does this pull request do? What does it change?**
Removes the find similar transactions option which currently causes a crash because we don't support searching. Also removes the converted price when copying a transaction to the clipboard as we don't have historical prices implemented.

