### PR TITLE
When removing an institution that is showing a reconnect dialog, it doesn't remove it from the dialog. #559

### DIFF
--- a/Balance/macOS/View Controllers/Tabs/View Controllers/AccountsTabViewController.swift
+++ b/Balance/macOS/View Controllers/Tabs/View Controllers/AccountsTabViewController.swift
@@ -401,9 +401,9 @@ class AccountsTabViewController: NSViewController, SectionedTableViewDelegate, S
                     }
                     
                     self.updateTotalBalance()
-                    
                     self.adjustWindowHeight()
-                    
+                    self.createFixPasswordPrompt()
+
                     // Scroll to the end of the table
                     async(after: self.institutionUpdateDelay) {
                         NSAnimationContext.runAnimationGroup({ context in
@@ -445,6 +445,7 @@ class AccountsTabViewController: NSViewController, SectionedTableViewDelegate, S
                 }
                 
                 self.updateTotalBalance()
+                self.createFixPasswordPrompt()
                 
                 // Only adjust if we're visible
                 if self.view.window != nil {


### PR DESCRIPTION
**Is this pull request adding a feature or fixing a bug?**  
bug

**Does this pull request close an issue? If so, which one?**
#559

**What does this pull request do? What does it change?**
Rebuilds the reconnect dialog when adding/removing an institution
